### PR TITLE
fix(ci): add issues:write permission to sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `issues: write` permission to sync workflow
- Fix: "Resource not accessible by integration" error when creating sync issues via github-script

## Test plan
- [ ] Sync workflow runs without permission error