### PR TITLE
feat(mesh): test hardening + brain viz + kanban + sparklines + node identity fix

### DIFF
--- a/config/mesh-heartbeat.schtasks.template
+++ b/config/mesh-heartbeat.schtasks.template
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers>
+    <TimeTrigger>
+      <Repetition>
+        <Interval>PT30S</Interval>
+        <StopAtDurationEnd>false</StopAtDurationEnd>
+      </Repetition>
+      <StartBoundary>2024-01-01T00:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+    </TimeTrigger>
+  </Triggers>
+  <Actions>
+    <Exec>
+      <Command>bash</Command>
+      <Arguments>-c "$CLAUDE_HOME/scripts/mesh-heartbeat.sh run-once"</Arguments>
+    </Exec>
+  </Actions>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <Hidden>true</Hidden>
+  </Settings>
+</Task>

--- a/config/peers.conf
+++ b/config/peers.conf
@@ -6,7 +6,7 @@
 # Fields:
 #   ssh_alias    - SSH config alias or hostname (string, required)
 #   user         - SSH username for this peer (string, required)
-#   os           - Operating system: macos | linux (string, required)
+#   os           - Operating system: macos | linux | windows (string, required)
 #   tailscale_ip - Tailscale IP address for private network access (string, e.g., 100.x.x.x)
 #   dns_name     - Tailscale DNS name (auto-discoverable via `tailscale status`)
 #   capabilities - Comma-separated list of available agents/tools: claude, copilot, ollama, opencode (string)

--- a/scripts/dashboard_web/api_dashboard.py
+++ b/scripts/dashboard_web/api_dashboard.py
@@ -138,7 +138,7 @@ def api_mission(resolve_host_to_peer) -> dict:
     for p in plans:
         p["execution_peer"] = resolve_host_to_peer(p.get("execution_host", ""))
         waves = query(
-            "SELECT wave_id,name,status,tasks_done,tasks_total,position FROM waves WHERE plan_id=? ORDER BY position",
+            "SELECT wave_id,name,depends_on,status,tasks_done,tasks_total,position FROM waves WHERE plan_id=? ORDER BY position",
             (p["id"],),
         )
         tasks = query(
@@ -259,7 +259,7 @@ def api_plan_detail(plan_id: int) -> dict | None:
     if not p:
         return None
     waves = query(
-        "SELECT wave_id,name,status,tasks_done,tasks_total,branch_name,pr_number,pr_url,position FROM waves WHERE plan_id=? ORDER BY position",
+        "SELECT wave_id,name,depends_on,status,tasks_done,tasks_total,branch_name,pr_number,pr_url,position FROM waves WHERE plan_id=? ORDER BY position",
         (plan_id,),
     )
     tasks = query(

--- a/scripts/dashboard_web/api_mesh.py
+++ b/scripts/dashboard_web/api_mesh.py
@@ -6,8 +6,10 @@ Internal helpers (heartbeat, remote plans, tailscale) live in lib/mesh_helpers.p
 
 import configparser
 import json
+import os
 import shlex
 import socket
+import sqlite3
 import subprocess
 import sys
 import time
@@ -113,6 +115,35 @@ def resolve_host_to_peer(host: str) -> str:
             ):
                 return p["peer_name"]
     return host
+
+
+_local_peer_cache: str | None = None
+
+
+def local_peer_name() -> str:
+    global _local_peer_cache
+    if _local_peer_cache is not None:
+        return _local_peer_cache
+    conf = parse_peers_conf()
+    # Match by Tailscale IP
+    try:
+        ts_ip = subprocess.run(
+            ["tailscale", "ip", "--4"], capture_output=True, text=True, timeout=5
+        ).stdout.strip()
+        for p in conf:
+            if p.get("tailscale_ip") == ts_ip:
+                _local_peer_cache = p["peer_name"]
+                return _local_peer_cache
+    except Exception:
+        pass
+    # Match by hostname
+    hn = socket.gethostname().lower().replace("-", "").replace("_", "").split(".")[0]
+    for p in conf:
+        if p.get("is_local") or peer_host_match(p["peer_name"], hn, is_local=True):
+            _local_peer_cache = p["peer_name"]
+            return _local_peer_cache
+    _local_peer_cache = socket.gethostname().split(".")[0]
+    return _local_peer_cache
 
 
 def api_mesh() -> list[dict]:
@@ -225,8 +256,65 @@ def api_mesh() -> list[dict]:
                 "mem_used_gb": mem_used,
                 "mem_total_gb": mem_total,
                 "plans": plans,
+                "local_peer_name": local_peer_name(),
             }
         )
+    return result
+
+
+def api_mesh_init() -> dict:
+    """POST /api/mesh/init — called once on first dashboard load."""
+    result = {"daemons_restarted": [], "hosts_needing_normalization": 0, "status": "ok"}
+
+    for daemon_name, script in [
+        ("mesh-coordinator", "mesh-coordinator.sh"),
+        ("mesh-heartbeat", "mesh-heartbeat.sh"),
+    ]:
+        pid_file = os.path.expanduser(f"~/.claude/cache/{daemon_name}.pid")
+        script_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", script))
+        if not (os.path.exists(pid_file) and os.path.exists(script_path)):
+            continue
+        try:
+            with open(pid_file, encoding="utf-8") as f:
+                pid = int(f.read().strip())
+            os.kill(pid, 0)  # process exists
+            script_mtime = os.path.getmtime(script_path)
+            pid_mtime = os.path.getmtime(pid_file)
+            if script_mtime > pid_mtime:
+                os.kill(pid, 15)
+                time.sleep(1)
+                subprocess.Popen(
+                    [script_path, "start"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                result["daemons_restarted"].append(daemon_name)
+        except (ProcessLookupError, ValueError, FileNotFoundError, PermissionError, OSError):
+            pass
+
+    try:
+        db_path = os.path.expanduser("~/.claude/data/dashboard.db")
+        peers = [p["peer_name"] for p in parse_peers_conf() if p.get("peer_name")]
+        if os.path.exists(db_path):
+            conn = sqlite3.connect(db_path, timeout=5)
+            try:
+                if peers:
+                    placeholders = ",".join("?" * len(peers))
+                    count = conn.execute(
+                        f"SELECT COUNT(*) FROM plans WHERE execution_host != '' "
+                        f"AND execution_host NOT IN ({placeholders})",
+                        peers,
+                    ).fetchone()[0]
+                else:
+                    count = conn.execute(
+                        "SELECT COUNT(*) FROM plans WHERE execution_host != ''"
+                    ).fetchone()[0]
+                result["hosts_needing_normalization"] = int(count or 0)
+            finally:
+                conn.close()
+    except Exception:
+        pass
+
     return result
 
 

--- a/scripts/dashboard_web/api_peers.py
+++ b/scripts/dashboard_web/api_peers.py
@@ -26,7 +26,7 @@ else:
 
 _writer = PeersWriter(PEERS_CONF)
 _REQUIRED_CREATE = ("ssh_alias", "user", "os", "role")
-_VALID_OS = ("macos", "linux")
+_VALID_OS = ("macos", "linux", "windows")
 _VALID_ROLES = ("coordinator", "worker", "hybrid")
 _VALID_ENGINES = ("claude", "copilot", "opencode", "ollama")
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
@@ -179,7 +179,7 @@ def api_peer_discover() -> dict:
                 "hostname": hostname,
                 "tailscale_ip": ts_ip,
                 "dns_name": info.get("DNSName", "").rstrip("."),
-                "os": "linux" if "linux" in info.get("OS", "").lower() else "macos",
+                "os": "windows" if "windows" in info.get("OS", "").lower() else ("linux" if "linux" in info.get("OS", "").lower() else "macos"),
                 "is_new": True,
             }
         )

--- a/scripts/dashboard_web/api_plans.py
+++ b/scripts/dashboard_web/api_plans.py
@@ -5,10 +5,14 @@ from pathlib import Path
 
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-    from scripts.dashboard_web.api_mesh import find_peer_conf, peer_host_match
+    from scripts.dashboard_web.api_mesh import (
+        find_peer_conf,
+        local_peer_name,
+        peer_host_match,
+    )
     from scripts.dashboard_web.middleware import DB_PATH, query
 else:
-    from .api_mesh import find_peer_conf, peer_host_match
+    from .api_mesh import find_peer_conf, local_peer_name, peer_host_match
     from .middleware import DB_PATH, query
 
 
@@ -145,7 +149,7 @@ def handle_pull_remote_db(handler, _qs: dict):
     peer_plans: dict[str, list[int]] = {}
     for p in plans:
         host = p["execution_host"]
-        if peer_host_match("m3max", host) or host == local_host:
+        if peer_host_match(local_peer_name(), host) or host == local_host:
             continue
         pc = find_peer_conf(host)
         ssh_dest = pc.get("ssh_alias", host) if pc else host

--- a/scripts/dashboard_web/api_plans_sse.py
+++ b/scripts/dashboard_web/api_plans_sse.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-    from scripts.dashboard_web.api_mesh import find_peer_conf
+    from scripts.dashboard_web.api_mesh import find_peer_conf, local_peer_name
     from scripts.dashboard_web.api_plans_checks import (
         check_cli_tools,
         check_disk,
@@ -22,7 +22,7 @@ if __package__ in (None, ""):
     from scripts.dashboard_web.lib.sse import run_command_sse
     from scripts.dashboard_web.middleware import DB_PATH, query_one
 else:
-    from .api_mesh import find_peer_conf
+    from .api_mesh import find_peer_conf, local_peer_name
     from .api_plans_checks import check_cli_tools, check_disk, check_heartbeat
     from .api_plans_preflight import (
         build_candidates,
@@ -184,7 +184,7 @@ def handle_plan_start_sse(handler, qs: dict):
     else:
         from .api_mesh import peer_host_match
 
-    if target == "local" or peer_host_match("m3max", target):
+    if target == "local" or peer_host_match(local_peer_name(), target):
         cmd = (
             f'claude --model sonnet -p "/execute {plan_id}"'
             if cli == "claude"

--- a/scripts/dashboard_web/app.js
+++ b/scripts/dashboard_web/app.js
@@ -1,6 +1,7 @@
 const $ = (s) => document.querySelector(s);
 const state = (window.DashboardState = window.DashboardState || {
   hostToPeer: {},
+  localPeerName: "local",
   lastMissionData: null,
   lastMeshData: null,
   lastOrganizationData: null,
@@ -34,13 +35,15 @@ async function fetchJson(url) {
 }
 
 function _resolveHost(host) {
-  if (!host) return "local";
+  if (!host) return "unknown";
   if (state.hostToPeer[host]) return state.hostToPeer[host];
-  const h = host.toLowerCase();
+  // Fuzzy: strip suffixes and special chars
+  const clean = host.toLowerCase().replace(/[-_]/g, "").replace(/\.(lan|local|tailnet)$/i, "");
   for (const [k, n] of Object.entries(state.hostToPeer)) {
-    if (h.includes(k.toLowerCase()) || k.toLowerCase().includes(h)) return n;
+    const cleanKey = k.toLowerCase().replace(/[-_]/g, "").replace(/\.(lan|local|tailnet)$/i, "");
+    if (cleanKey === clean) return n;
   }
-  return host.length > 20 ? host.substring(0, 16) + "…" : host;
+  return host;
 }
 
 async function _pullRemoteDb() {
@@ -80,14 +83,27 @@ async function refreshAll() {
     if (typeof renderKpi === "function") renderKpi(ov);
   }
   if (Array.isArray(mesh)) {
+    state.localPeerName = mesh.find((p) => p.is_local)?.peer_name || "local";
     state.hostToPeer = {};
     mesh.forEach((p) => {
-      state.hostToPeer[p.peer_name] = p.peer_name;
-      if (p.dns_name) state.hostToPeer[p.dns_name] = p.peer_name;
-      if (p.is_local) state.hostToPeer.local = p.peer_name;
+      const name = p.peer_name || p.name;
+      if (name) {
+        state.hostToPeer[name] = name;
+        if (p.dns_name) state.hostToPeer[p.dns_name] = name;
+        if (p.ssh_alias) state.hostToPeer[p.ssh_alias] = name;
+        if (p.tailscale_ip) state.hostToPeer[p.tailscale_ip] = name;
+        if (p.is_local) state.hostToPeer.local = name;
+        // Register hostname variants for local peer
+        if (p.is_local && Array.isArray(p.hostname_aliases)) {
+          p.hostname_aliases.forEach((alias) => {
+            if (alias) state.hostToPeer[alias] = name;
+          });
+        }
+      }
     });
   }
   if (typeof renderMission === "function") renderMission(mission);
+  if (typeof renderKanban === "function") renderKanban();
   if (daily && typeof renderTokenChart === "function") renderTokenChart(daily);
   if (models && typeof renderModelChart === "function") renderModelChart(models);
   if (mesh && typeof renderMeshStrip === "function") {
@@ -102,12 +118,30 @@ async function refreshAll() {
   if (typeof renderAgentOrganization === "function") renderAgentOrganization(organization);
   if (liveSystem) state.lastLiveSystemData = liveSystem;
   if (typeof renderLiveSystem === "function") renderLiveSystem(liveSystem);
+  if (window._brainActive && window.updateBrainData && liveSystem) {
+    window.updateBrainData(liveSystem);
+  }
   if (history && typeof renderHistory === "function") renderHistory(history);
   if (dist && typeof renderDist === "function") renderDist(dist);
   const lu = $("#last-update");
   if (lu) lu.textContent = `Updated: ${new Date().toLocaleTimeString()}`;
   _pullRemoteDb();
 }
+
+window.toggleBrainCanvas = function () {
+  const container = document.getElementById("brain-activity");
+  if (!container) return;
+  if (window._brainActive) {
+    if (window.destroyBrainCanvas) window.destroyBrainCanvas();
+    container.style.display = "none";
+    window._brainActive = false;
+  } else {
+    container.style.display = "block";
+    if (window.initBrainCanvas) window.initBrainCanvas("brain-canvas-container");
+    window._brainActive = true;
+    if (typeof refreshAll === "function") refreshAll();
+  }
+};
 
 function updateClock() {
   const el = $("#clock");
@@ -181,6 +215,18 @@ document.addEventListener("DOMContentLoaded", () => {
   applyZoom(state.currentZoom);
   updateClock();
   setInterval(updateClock, 1000);
+  // First-load only — NOT in periodic refreshAll
+  fetch("/api/mesh/init", { method: "POST" })
+    .then((r) => r.json())
+    .then((data) => {
+      if (data.daemons_restarted && data.daemons_restarted.length > 0) {
+        showToast(`Restarted: ${data.daemons_restarted.join(", ")}`, "info");
+      }
+      if (data.hosts_needing_normalization > 0) {
+        showToast(`${data.hosts_needing_normalization} plans need host normalization`, "warn");
+      }
+    })
+    .catch(() => {});
   refreshAll();
   applyRefresh();
   setTimeout(handleHashRoute, 1200);

--- a/scripts/dashboard_web/brain-canvas.js
+++ b/scripts/dashboard_web/brain-canvas.js
@@ -1,0 +1,187 @@
+(() => {
+  const S = {
+    container: null, canvas: null, ctx: null, ro: null, raf: 0,
+    snapshot: { peer_nodes: [], run_nodes: [], synapses: [] },
+    w: 0, h: 0, id: null, running: true, positions: { plans: {}, tasks: {}, peers: {} },
+    particles: new Map(),
+  };
+
+  const C = { cyan: '#00e5ff', red: '#ff3366', green: '#00ff88', gold: '#ffd700', dim: '#3a4466', off: '#1a2040' };
+  const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+  const lerp = (a, b, t) => a + (b - a) * t;
+
+  function planKey(id) { return `plan:${id ?? 'unknown'}`; }
+  function taskKey(r) { return r.id || `task:${r.task_id || Math.random()}`; }
+  function runState(s) {
+    if (s === 'running' || s === 'doing' || s === 'waiting') return 'in_progress';
+    if (s === 'validating' || s === 'submitted') return 'submitted';
+    if (s === 'blocked') return 'blocked';
+    return 'pending';
+  }
+  function planState(tasks) {
+    if (tasks.some((t) => runState(t.status) === 'blocked')) return 'blocked';
+    if (tasks.some((t) => ['in_progress', 'submitted'].includes(runState(t.status)))) return 'doing';
+    return 'todo';
+  }
+
+  function size() {
+    if (!S.container || !S.canvas) return;
+    const r = S.container.getBoundingClientRect();
+    S.w = Math.max(10, r.width); S.h = Math.max(10, r.height);
+    const dpr = window.devicePixelRatio || 1;
+    S.canvas.width = Math.floor(S.w * dpr); S.canvas.height = Math.floor(S.h * dpr);
+    S.canvas.style.width = `${S.w}px`; S.canvas.style.height = `${S.h}px`;
+    S.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  function fallbackLayout(plans, tasks, peers, t) {
+    const cx = S.w / 2, cy = S.h / 2;
+    const pr = Math.min(S.w, S.h) * 0.26;
+    plans.forEach((p, i) => {
+      const a = (i / Math.max(1, plans.length)) * Math.PI * 2 - Math.PI / 2;
+      S.positions.plans[p.id] = { x: cx + Math.cos(a) * pr, y: cy + Math.sin(a) * pr };
+    });
+    peers.forEach((p, i) => {
+      const a = (i / Math.max(1, peers.length)) * Math.PI * 2 + t * 0.05;
+      const rr = Math.min(S.w, S.h) * 0.45;
+      S.positions.peers[p.id] = { x: cx + Math.cos(a) * rr, y: cy + Math.sin(a) * rr };
+    });
+    const grouped = tasks.reduce((m, r) => ((m[r.plan_id] ||= []).push(r), m), {});
+    Object.keys(grouped).forEach((pid) => grouped[pid].forEach((r, i) => {
+      const p = S.positions.plans[planKey(pid)] || { x: cx, y: cy };
+      const a = (i / Math.max(1, grouped[pid].length)) * Math.PI * 2 + t * 0.001 * (0.8 + i * 0.05);
+      const d = 60 + (i % 4) * 6;
+      S.positions.tasks[taskKey(r)] = { x: p.x + Math.cos(a) * d, y: p.y + Math.sin(a) * d };
+    }));
+  }
+
+  function layout(now) {
+    const runs = S.snapshot.run_nodes || [], peers = S.snapshot.peer_nodes || [];
+    const byPlan = runs.reduce((m, r) => ((m[r.plan_id ?? 'unknown'] ||= []).push(r), m), {});
+    const plans = Object.keys(byPlan).map((id) => ({ id: planKey(id), raw: id, tasks: byPlan[id], status: planState(byPlan[id]) }));
+    const bl = window.BrainLayout;
+    if (bl) {
+      const payload = { plans, tasks: runs, peers, width: S.w, height: S.h, prev: S.positions, now };
+      let pos = null;
+      if (typeof bl.compute === 'function') pos = bl.compute(payload);
+      else if (typeof bl.layout === 'function') pos = bl.layout(payload);
+      else if (typeof bl.getPositions === 'function') pos = bl.getPositions(payload);
+      if (pos?.plans && pos?.tasks && pos?.peers) S.positions = pos; else fallbackLayout(plans, runs, peers, now);
+    } else fallbackLayout(plans, runs, peers, now);
+    return { plans, runs, peers };
+  }
+
+  function drawHex(x, y, r, stroke, fill, level) {
+    const c = S.ctx; c.save(); c.translate(x, y);
+    c.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const a = Math.PI / 6 + (i * Math.PI) / 3;
+      const px = Math.cos(a) * r, py = Math.sin(a) * r;
+      if (!i) c.moveTo(px, py); else c.lineTo(px, py);
+    }
+    c.closePath(); c.strokeStyle = stroke; c.lineWidth = 2; c.stroke();
+    c.save(); c.clip(); c.fillStyle = fill;
+    c.fillRect(-r, r - 2 * r * clamp(level, 0, 1), 2 * r, 2 * r);
+    c.restore(); c.restore();
+  }
+
+  function bezierPoint(p0, p1, p2, p3, t) {
+    const u = 1 - t;
+    const x = u * u * u * p0.x + 3 * u * u * t * p1.x + 3 * u * t * t * p2.x + t * t * t * p3.x;
+    const y = u * u * u * p0.y + 3 * u * u * t * p1.y + 3 * u * t * t * p2.y + t * t * t * p3.y;
+    return { x, y };
+  }
+
+  function render(ts) {
+    if (!S.ctx || !S.running) return;
+    const c = S.ctx; c.clearRect(0, 0, S.w, S.h);
+    const { plans, runs, peers } = layout(ts);
+    const active = runs.filter((r) => runState(r.status) === 'in_progress').length;
+    const intensity = active === 0 ? { p: 2000, g: 0.25, e: 0 } : active < 3 ? { p: 1000, g: 0.55, e: 0.4 } : { p: 500, g: 0.95, e: 0.9 };
+    const pulse = 0.5 + 0.5 * Math.sin((ts / intensity.p) * Math.PI * 2);
+
+    (S.snapshot.synapses || []).forEach((s, i) => {
+      if (!String(s.source).startsWith('peer:')) return;
+      const a = S.positions.peers[s.source], b = S.positions.tasks[s.target]; if (!a || !b) return;
+      const dy = (b.y - a.y) * 0.15, bend = ((i % 2) ? 1 : -1) * (25 + 18 * intensity.e);
+      const p1 = { x: lerp(a.x, b.x, 0.35), y: a.y + dy + bend }, p2 = { x: lerp(a.x, b.x, 0.65), y: b.y - dy - bend };
+      c.beginPath(); c.moveTo(a.x, a.y); c.bezierCurveTo(p1.x, p1.y, p2.x, p2.y, b.x, b.y);
+      c.strokeStyle = `rgba(0,229,255,${0.15 + 0.4 * intensity.g})`; c.lineWidth = 1.2 + intensity.e * 1.3; c.stroke();
+      const rs = runState((runs.find((r) => taskKey(r) === s.target) || {}).status);
+      const targetN = rs === 'in_progress' ? 3 : rs === 'submitted' ? 1 : 0;
+      const key = `${s.source}->${s.target}`; let arr = S.particles.get(key) || [];
+      while (arr.length < targetN) arr.push({ t: Math.random(), v: 0.002 + Math.random() * 0.002 });
+      arr = arr.slice(0, targetN); arr.forEach((p) => { p.t = (p.t + p.v * (1 + intensity.e * 1.5)) % 1; });
+      S.particles.set(key, arr);
+      arr.forEach((p) => {
+        for (let k = 0; k < 3; k++) {
+          const tt = (p.t - k * 0.03 + 1) % 1, q = bezierPoint(a, p1, p2, b, tt);
+          c.fillStyle = `rgba(0,229,255,${0.9 - k * 0.28})`; c.beginPath(); c.arc(q.x, q.y, 3 - k * 0.5, 0, Math.PI * 2); c.fill();
+        }
+      });
+    });
+
+    plans.forEach((p) => {
+      const pos = S.positions.plans[p.id]; if (!pos) return;
+      const col = p.status === 'doing' ? C.cyan : p.status === 'blocked' ? C.red : C.dim;
+      const amp = clamp((p.tasks.length || 0) / 5, 0.2, 1.4);
+      const ring = 36 + (2 + 8 * amp) * pulse;
+      c.shadowBlur = 18 * intensity.g + 10 * pulse; c.shadowColor = col;
+      c.beginPath(); c.arc(pos.x, pos.y, ring, 0, Math.PI * 2); c.strokeStyle = `${col}99`; c.lineWidth = 2 + intensity.e; c.stroke();
+      const g = c.createRadialGradient(pos.x - 8, pos.y - 8, 8, pos.x, pos.y, 30);
+      g.addColorStop(0, `${col}cc`); g.addColorStop(1, `${col}33`);
+      c.fillStyle = g; c.beginPath(); c.arc(pos.x, pos.y, 30, 0, Math.PI * 2); c.fill();
+      c.shadowBlur = 0; c.fillStyle = '#d7e7ff'; c.font = '12px Inter, system-ui, sans-serif'; c.textAlign = 'center';
+      const raw = String(p.raw); c.fillText(`#${raw} Plan`, pos.x, pos.y + 48);
+    });
+
+    runs.forEach((r) => {
+      const p = S.positions.tasks[taskKey(r)]; if (!p) return;
+      const st = runState(r.status); const col = st === 'in_progress' ? C.green : st === 'submitted' ? C.gold : st === 'blocked' ? C.red : C.dim;
+      const age = Math.max(0, ((S.snapshot.generated_at || Date.now() / 1000) - (r.last_seen || S.snapshot.generated_at || 0)));
+      const hot = clamp(1 - age / 20, 0, 1); c.shadowBlur = 8 + hot * 14; c.shadowColor = col;
+      c.fillStyle = `${col}${st === 'pending' ? '66' : 'cc'}`; c.beginPath(); c.arc(p.x, p.y, 16, 0, Math.PI * 2); c.fill(); c.shadowBlur = 0;
+      c.fillStyle = '#0a1024'; c.font = 'bold 12px JetBrains Mono, monospace'; c.textAlign = 'center'; c.textBaseline = 'middle';
+      const a = String(r.agent_name || '').toLowerCase(); c.fillText(a.includes('claude') ? '◆' : a.includes('copilot') ? '⬡' : '●', p.x, p.y + 0.5);
+    });
+
+    peers.forEach((peer) => {
+      const p = S.positions.peers[peer.id]; if (!p) return;
+      drawHex(p.x, p.y, 20, peer.is_online ? C.cyan : C.off, 'rgba(0,229,255,0.25)', (peer.cpu || 0) / 100);
+      c.fillStyle = '#aac4ff'; c.font = '11px Inter, system-ui, sans-serif'; c.textAlign = 'center'; c.fillText(peer.peer_name || 'peer', p.x, p.y + 32);
+    });
+
+    if (intensity.e > 0.8) {
+      c.strokeStyle = 'rgba(0,229,255,0.25)'; c.lineWidth = 3; c.strokeRect(1.5, 1.5, S.w - 3, S.h - 3);
+    }
+    S.raf = requestAnimationFrame(render);
+  }
+
+  function onVis() {
+    S.running = !document.hidden;
+    if (S.running && !S.raf) S.raf = requestAnimationFrame(render);
+    if (!S.running && S.raf) { cancelAnimationFrame(S.raf); S.raf = 0; }
+  }
+
+  window.initBrainCanvas = function initBrainCanvas(containerId) {
+    window.destroyBrainCanvas();
+    S.id = containerId; S.container = document.getElementById(containerId); if (!S.container) return;
+    S.canvas = document.createElement('canvas'); S.canvas.className = 'brain-canvas'; S.container.appendChild(S.canvas);
+    S.ctx = S.canvas.getContext('2d', { alpha: true }); size();
+    S.ro = new ResizeObserver(size); S.ro.observe(S.container); window.addEventListener('resize', size);
+    document.addEventListener('visibilitychange', onVis); S.running = !document.hidden; S.raf = requestAnimationFrame(render);
+  };
+
+  window.updateBrainData = function updateBrainData(snapshot) {
+    if (!snapshot) return;
+    S.snapshot = { ...snapshot, peer_nodes: snapshot.peer_nodes || [], run_nodes: snapshot.run_nodes || [], synapses: snapshot.synapses || [] };
+  };
+
+  window.destroyBrainCanvas = function destroyBrainCanvas() {
+    if (S.raf) cancelAnimationFrame(S.raf); S.raf = 0;
+    if (S.ro) S.ro.disconnect(); S.ro = null;
+    window.removeEventListener('resize', size); document.removeEventListener('visibilitychange', onVis);
+    if (S.canvas?.parentNode) S.canvas.parentNode.removeChild(S.canvas);
+    S.container = S.canvas = S.ctx = null; S.particles.clear();
+  };
+})();

--- a/scripts/dashboard_web/brain-layout.js
+++ b/scripts/dashboard_web/brain-layout.js
@@ -1,0 +1,201 @@
+class BrainLayout {
+  constructor(width, height) {
+    this.width = width; this.height = height;
+    this.repulsionK = 500; this.springK = 0.05; this.restLength = 100;
+    this.centerK = 0.01; this.damping = 0.92;
+    this.nodes = []; this.nodeMap = new Map(); this.synapses = [];
+  }
+
+  setNodes(nodes) {
+    const prev = this.nodeMap;
+    const incoming = nodes.map(n => ({ ...n }));
+    const byId = new Map(incoming.map(n => [n.id, n]));
+    const cx = this.width * 0.5, cy = this.height * 0.5;
+    const massByType = { plan: 3, task: 1, peer: 2 };
+
+    for (const n of incoming) {
+      const old = prev.get(n.id);
+      n.mass = n.mass || massByType[n.type] || 1;
+      if (old) {
+        n.x = old.x; n.y = old.y; n.vx = old.vx; n.vy = old.vy;
+        continue;
+      }
+      if (typeof n.x !== 'number' || typeof n.y !== 'number') {
+        const p = prev.get(n.parentId) || byId.get(n.parentId);
+        if (p && typeof p.x === 'number' && typeof p.y === 'number') {
+          n.x = p.x + (Math.random() - 0.5) * 40;
+          n.y = p.y + (Math.random() - 0.5) * 40;
+        } else {
+          n.x = cx + (Math.random() - 0.5) * 80;
+          n.y = cy + (Math.random() - 0.5) * 80;
+        }
+      }
+      n.vx = n.vx || 0; n.vy = n.vy || 0;
+    }
+
+    this.nodes = incoming;
+    this.nodeMap = new Map(incoming.map(n => [n.id, n]));
+    this.synapses = this.synapses.filter(s => this.nodeMap.has(s.source) && this.nodeMap.has(s.target));
+  }
+
+  setSynapses(synapses) {
+    this.synapses = synapses.filter(s => this.nodeMap.has(s.source) && this.nodeMap.has(s.target));
+  }
+
+  step() {
+    const n = this.nodes.length;
+    if (!n) return;
+    const fx = new Array(n).fill(0), fy = new Array(n).fill(0);
+    const cx = this.width * 0.5, cy = this.height * 0.5;
+    const ringR = 0.4 * Math.min(this.width, this.height);
+
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        const a = this.nodes[i], b = this.nodes[j];
+        const dx = b.x - a.x, dy = b.y - a.y;
+        const d2 = dx * dx + dy * dy + 0.01;
+        const d = Math.sqrt(d2);
+        const f = this.repulsionK / d2;
+        const ux = dx / d, uy = dy / d;
+        fx[i] -= f * ux; fy[i] -= f * uy;
+        fx[j] += f * ux; fy[j] += f * uy;
+      }
+    }
+
+    for (const s of this.synapses) {
+      const a = this.nodeMap.get(s.source), b = this.nodeMap.get(s.target);
+      if (!a || !b) continue;
+      const i = this.nodes.indexOf(a), j = this.nodes.indexOf(b);
+      const dx = b.x - a.x, dy = b.y - a.y;
+      const d = Math.hypot(dx, dy) || 1;
+      const ux = dx / d, uy = dy / d;
+      const f = this.springK * (d - this.restLength);
+      fx[i] += f * ux; fy[i] += f * uy;
+      fx[j] -= f * ux; fy[j] -= f * uy;
+    }
+
+    for (let i = 0; i < n; i++) {
+      const node = this.nodes[i];
+      fx[i] += (cx - node.x) * this.centerK;
+      fy[i] += (cy - node.y) * this.centerK;
+      node.vx = (node.vx + fx[i] / node.mass) * this.damping;
+      node.vy = (node.vy + fy[i] / node.mass) * this.damping;
+      node.x += node.vx; node.y += node.vy;
+
+      if (node.type === 'peer') {
+        let ang = Math.atan2(node.y - cy, node.x - cx);
+        if (!Number.isFinite(ang)) ang = Math.random() * Math.PI * 2;
+        node.x = cx + Math.cos(ang) * ringR;
+        node.y = cy + Math.sin(ang) * ringR;
+        node.vx *= 0.5; node.vy *= 0.5;
+      }
+    }
+  }
+
+  getPositions() {
+    const out = {};
+    for (const n of this.nodes) out[n.id] = { x: n.x, y: n.y };
+    return out;
+  }
+}
+
+class ParticleSystem {
+  constructor(maxParticles = 200) {
+    this.maxParticles = maxParticles;
+    this.active = []; this.pool = [];
+  }
+
+  spawn(synapse, color = '#7cf', speed = 0.02) {
+    if (this.active.length >= this.maxParticles) return;
+    const s = this._pt(synapse.source || synapse.s || { x: synapse.x1, y: synapse.y1 });
+    const t = this._pt(synapse.target || synapse.t || { x: synapse.x2, y: synapse.y2 });
+    if (!s || !t) return;
+    const p = this.pool.pop() || {};
+    const dx = t.x - s.x, dy = t.y - s.y, len = Math.hypot(dx, dy) || 1;
+    const nx = -dy / len, ny = dx / len;
+    const curve = Math.min(40, len * 0.25) * (0.7 + Math.random() * 0.6);
+    p.x1 = s.x; p.y1 = s.y; p.x2 = t.x; p.y2 = t.y;
+    p.cx = (s.x + t.x) * 0.5 + nx * curve; p.cy = (s.y + t.y) * 0.5 + ny * curve;
+    p.t = 0; p.speed = speed; p.size = 1 + Math.random() * 1.8;
+    p.color = color; p.opacity = 1; p.lifetime = 1; p.trail = p.trail || []; p.trail.length = 0;
+    this.active.push(p);
+  }
+
+  update() {
+    for (let i = this.active.length - 1; i >= 0; i--) {
+      const p = this.active[i];
+      p.t += p.speed;
+      if (p.t >= p.lifetime) {
+        this.pool.push(this.active.splice(i, 1)[0]);
+        continue;
+      }
+      const t = p.t / p.lifetime, u = 1 - t;
+      p.x = u * u * p.x1 + 2 * u * t * p.cx + t * t * p.x2;
+      p.y = u * u * p.y1 + 2 * u * t * p.cy + t * t * p.y2;
+      p.trail.push({ x: p.x, y: p.y });
+      if (p.trail.length > 3) p.trail.shift();
+      p.opacity = t > 0.8 ? (1 - t) / 0.2 : 1;
+    }
+  }
+
+  render(ctx) {
+    const trailAlpha = [0.2, 0.5, 1.0];
+    ctx.save();
+    for (const p of this.active) {
+      for (let i = 0; i < p.trail.length; i++) {
+        const tr = p.trail[i];
+        ctx.globalAlpha = p.opacity * trailAlpha[Math.max(0, 3 - p.trail.length + i)];
+        ctx.fillStyle = p.color;
+        ctx.beginPath(); ctx.arc(tr.x, tr.y, p.size * (0.5 + i * 0.25), 0, Math.PI * 2); ctx.fill();
+      }
+      ctx.globalAlpha = p.opacity;
+      ctx.fillStyle = p.color;
+      ctx.beginPath(); ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  _pt(v) {
+    if (!v || typeof v.x !== 'number' || typeof v.y !== 'number') return null;
+    return { x: v.x, y: v.y };
+  }
+}
+
+class GlowSystem {
+  constructor() { this.pulses = new Map(); this.baseRadius = 12; }
+
+  setPulse(nodeId, frequency, amplitude) {
+    this.pulses.set(nodeId, { frequency: frequency || 1, amplitude: amplitude || 0 });
+  }
+
+  getGlow(nodeId, time) {
+    const p = this.pulses.get(nodeId) || { frequency: 1, amplitude: 0 };
+    const wave = Math.sin(time * p.frequency * Math.PI * 2);
+    const radius = this.baseRadius + p.amplitude * wave;
+    const opacity = 0.2 + Math.abs(wave) * 0.4;
+    return { radius, opacity };
+  }
+
+  renderEdgeGlow(ctx, width, height, intensity) {
+    const a = Math.max(0, intensity) * 0.1;
+    if (!a) return;
+    ctx.save();
+    const gTop = ctx.createLinearGradient(0, 0, 0, height * 0.35);
+    gTop.addColorStop(0, `rgba(120,180,255,${a})`); gTop.addColorStop(1, 'rgba(120,180,255,0)');
+    const gBot = ctx.createLinearGradient(0, height, 0, height * 0.65);
+    gBot.addColorStop(0, `rgba(120,180,255,${a})`); gBot.addColorStop(1, 'rgba(120,180,255,0)');
+    const gLeft = ctx.createLinearGradient(0, 0, width * 0.35, 0);
+    gLeft.addColorStop(0, `rgba(120,180,255,${a})`); gLeft.addColorStop(1, 'rgba(120,180,255,0)');
+    const gRight = ctx.createLinearGradient(width, 0, width * 0.65, 0);
+    gRight.addColorStop(0, `rgba(120,180,255,${a})`); gRight.addColorStop(1, 'rgba(120,180,255,0)');
+    ctx.fillStyle = gTop; ctx.fillRect(0, 0, width, height * 0.35);
+    ctx.fillStyle = gBot; ctx.fillRect(0, height * 0.65, width, height * 0.35);
+    ctx.fillStyle = gLeft; ctx.fillRect(0, 0, width * 0.35, height);
+    ctx.fillStyle = gRight; ctx.fillRect(width * 0.65, 0, width * 0.35, height);
+    ctx.restore();
+  }
+}
+
+window.BrainLayout = BrainLayout;
+window.ParticleSystem = ParticleSystem;
+window.GlowSystem = GlowSystem;

--- a/scripts/dashboard_web/brain-styles.css
+++ b/scripts/dashboard_web/brain-styles.css
@@ -1,0 +1,42 @@
+.brain-container {
+  background: #0a0f1a;
+  border: 1px solid rgba(0, 229, 255, 0.2);
+  border-radius: 12px;
+  margin: 12px 0;
+  overflow: hidden;
+}
+.brain-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px;
+  border-bottom: 1px solid rgba(0, 229, 255, 0.1);
+}
+.brain-title {
+  color: #00e5ff;
+  font-size: 14px;
+  font-weight: 600;
+}
+.brain-toggle {
+  background: transparent;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px 8px;
+}
+.brain-toggle:hover {
+  color: #00e5ff;
+}
+.btn-brain {
+  background: rgba(0, 229, 255, 0.1);
+  border: 1px solid rgba(0, 229, 255, 0.3);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px 8px;
+  margin-left: 8px;
+}
+.btn-brain:hover {
+  background: rgba(0, 229, 255, 0.2);
+}

--- a/scripts/dashboard_web/css/components-3.css
+++ b/scripts/dashboard_web/css/components-3.css
@@ -41,30 +41,50 @@
 
 .task-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: 12px;
   table-layout: fixed;
 }
 .task-table th {
   text-align: left;
-  padding: 6px 8px;
+  padding: 8px 10px;
   font-size: 10px;
   letter-spacing: 1px;
   color: var(--cyan);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 2px solid var(--border);
   text-transform: uppercase;
-  font-weight: 400;
+  font-weight: 600;
+  background: rgba(0, 229, 255, 0.03);
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
+.task-table th:first-child { border-radius: 6px 0 0 0; }
+.task-table th:last-child { border-radius: 0 6px 0 0; }
 .task-table td {
-  padding: 5px 8px;
-  border-bottom: 1px solid #0d1228;
+  padding: 7px 10px;
+  border-bottom: 1px solid rgba(13, 18, 40, 0.6);
   cursor: pointer;
+  vertical-align: middle;
 }
 .task-table tr:hover td {
   background: rgba(0, 229, 255, 0.04);
 }
 .task-table tr.expanded td {
   background: rgba(0, 229, 255, 0.06);
+}
+.task-wave-header td {
+  padding: 10px 10px 6px;
+  border-bottom: 1px solid rgba(0, 229, 255, 0.1);
+  background: rgba(0, 229, 255, 0.02);
+  font-weight: 600;
+}
+.task-group-header td {
+  padding: 12px 10px 8px;
+  border-bottom: 2px solid rgba(0, 229, 255, 0.15);
+  background: rgba(0, 229, 255, 0.04);
+  font-size: 13px;
 }
 .task-detail {
   padding: 8px;

--- a/scripts/dashboard_web/index.html
+++ b/scripts/dashboard_web/index.html
@@ -56,6 +56,13 @@
     <div class="widget" id="mission-panel">
       <div class="widget-header"><span class="widget-title">Active Missions</span></div>
       <div class="widget-body" id="mission-content"><span style="color:var(--text-dim)">Loading...</span></div>
+      <div id="brain-activity" class="brain-container" style="display:none;">
+        <div class="brain-header">
+          <span class="brain-title">🧠 Neural Activity</span>
+          <button onclick="toggleBrainCanvas()" class="brain-toggle">✕</button>
+        </div>
+        <div id="brain-canvas-container" style="width:100%;height:300px;"></div>
+      </div>
     </div>
     <div class="widget" id="task-pipeline-widget" style="max-height:420px; overflow-y:auto">
       <div class="widget-header">
@@ -83,6 +90,25 @@
     <div class="widget" id="widget-dist">
       <div class="widget-header"><span class="widget-title">Task Distribution</span></div>
       <div class="widget-body"><div class="chart-container chart-container-sm"><canvas id="dist-chart"></canvas></div></div>
+    </div>
+    <div class="widget" id="plan-kanban-widget">
+      <div class="widget-header"><span class="widget-title">Plan Pipeline</span></div>
+      <div class="widget-body" style="padding:8px">
+        <div class="kanban-board" id="kanban-board">
+          <div class="kanban-col" data-status="todo" ondragover="event.preventDefault();this.classList.add('drag-over')" ondragleave="this.classList.remove('drag-over')" ondrop="kanbanDrop(event,'todo')">
+            <div class="kanban-col-header"><span class="kanban-dot todo"></span>Pipeline</div>
+            <div class="kanban-cards" id="kanban-todo"></div>
+          </div>
+          <div class="kanban-col" data-status="doing" ondragover="event.preventDefault();this.classList.add('drag-over')" ondragleave="this.classList.remove('drag-over')" ondrop="kanbanDrop(event,'doing')">
+            <div class="kanban-col-header"><span class="kanban-dot doing"></span>Executing</div>
+            <div class="kanban-cards" id="kanban-doing"></div>
+          </div>
+          <div class="kanban-col" data-status="done" ondragover="event.preventDefault();this.classList.add('drag-over')" ondragleave="this.classList.remove('drag-over')" ondrop="kanbanDrop(event,'done')">
+            <div class="kanban-col-header"><span class="kanban-dot done"></span>Done</div>
+            <div class="kanban-cards" id="kanban-done"></div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div class="dash-col-right">
@@ -164,10 +190,13 @@
 <script src="org-chart.js"></script>
 <script src="live-system.js"></script>
 <script src="task-pipeline.js"></script>
+<script src="plan-kanban.js"></script>
 <script src="charts.js"></script>
 <script src="activity.js"></script>
 <script src="kpi-modals.js"></script>
 <script src="websocket.js"></script>
+<script src="/brain-layout.js"></script>
+<script src="/brain-canvas.js"></script>
 <script src="app.js"></script>
 <script src="mesh.js"></script>
 <script src="mesh-animation.js"></script>

--- a/scripts/dashboard_web/kanban-styles.css
+++ b/scripts/dashboard_web/kanban-styles.css
@@ -1,0 +1,105 @@
+/* Plan Kanban Board */
+.kanban-board {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  min-height: 120px;
+}
+.kanban-col {
+  background: rgba(10, 14, 26, 0.5);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px;
+  min-height: 100px;
+  transition: border-color 0.2s;
+}
+.kanban-col.drag-over {
+  border-color: var(--cyan);
+  background: rgba(0, 229, 255, 0.04);
+}
+.kanban-col-header {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-dim);
+  padding: 4px 6px 8px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.kanban-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.kanban-dot.todo { background: var(--text-dim); }
+.kanban-dot.doing { background: var(--cyan); box-shadow: 0 0 6px var(--cyan); }
+.kanban-dot.done { background: var(--green); }
+.kanban-cards { display: flex; flex-direction: column; gap: 4px; }
+.kanban-card {
+  background: rgba(20, 28, 50, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  padding: 6px 8px;
+  cursor: grab;
+  transition: transform 0.15s, box-shadow 0.15s;
+  font-size: 11px;
+}
+.kanban-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  border-color: rgba(0, 229, 255, 0.2);
+}
+.kanban-card.dragging { opacity: 0.4; }
+.kanban-card-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.kanban-plan-id { color: var(--cyan); font-weight: 700; font-size: 10px; }
+.kanban-plan-name { color: var(--text); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kanban-progress {
+  height: 3px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+.kanban-progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.6s ease;
+}
+.kanban-card-meta {
+  font-size: 9px;
+  color: var(--text-dim);
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.kanban-running { color: var(--gold); }
+.kanban-host { color: var(--cyan); opacity: 0.6; }
+.kanban-empty { color: var(--text-dim); font-size: 10px; text-align: center; padding: 16px 0; font-style: italic; }
+
+/* Sparkline charts for mesh nodes */
+.mn-sparkline {
+  display: block;
+  width: 120px;
+  height: 28px;
+  border-radius: 3px;
+  background: rgba(10, 14, 26, 0.4);
+}
+.mn-gauge-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mn-gauge-val {
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 28px;
+  text-align: right;
+}

--- a/scripts/dashboard_web/mission.js
+++ b/scripts/dashboard_web/mission.js
@@ -1,8 +1,16 @@
+function _progressGradient(pct) {
+  // Red→Orange→Gold→Green as completion approaches 100%
+  if (pct >= 100) return { color: "#00cc6a", gradient: "linear-gradient(90deg, #00cc6a, #00ff88)" };
+  if (pct >= 75) return { color: "#4dd64d", gradient: "linear-gradient(90deg, #e6a117, #4dd64d)" };
+  if (pct >= 50) return { color: "#e6a117", gradient: "linear-gradient(90deg, #ff6633, #e6a117)" };
+  if (pct >= 25) return { color: "#ff6633", gradient: "linear-gradient(90deg, #ee3344, #ff6633)" };
+  return { color: "#ee3344", gradient: "linear-gradient(90deg, #cc1133, #ee3344)" };
+}
 function _progressRing(pct, size, color) {
   const r = (size - 8) / 2,
     c = 2 * Math.PI * r,
     o = c - (pct / 100) * c;
-  return `<div class="mission-ring" style="width:${size}px;height:${size}px"><svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}"><circle class="mission-ring-bg" cx="${size / 2}" cy="${size / 2}" r="${r}"/><circle class="mission-ring-fill" cx="${size / 2}" cy="${size / 2}" r="${r}" stroke="${color}" stroke-dasharray="${c}" stroke-dashoffset="${o}"/></svg><div class="mission-ring-pct" style="color:${color}">${pct}%</div></div>`;
+  return `<div class="mission-ring" style="width:${size}px;height:${size}px"><svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}"><defs><linearGradient id="ring-grad-${pct}" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="${pct < 50 ? '#ee3344' : '#e6a117'}"/><stop offset="100%" stop-color="${color}"/></linearGradient></defs><circle class="mission-ring-bg" cx="${size / 2}" cy="${size / 2}" r="${r}"/><circle class="mission-ring-fill" cx="${size / 2}" cy="${size / 2}" r="${r}" stroke="url(#ring-grad-${pct})" stroke-dasharray="${c}" stroke-dashoffset="${o}"/></svg><div class="mission-ring-pct" style="color:${color}">${pct}%</div></div>`;
 }
 function _shortModel(m) {
   if (!m) return "";
@@ -39,6 +47,71 @@ function _renderTaskFlow(t) {
       return `<div class="flow-step ${cls}"><div class="flow-dot"></div><div class="flow-label">${s.label}</div></div>${i < steps.length - 1 ? `<div class="flow-conn ${pi ? "conn-done" : ai ? "conn-active" : ""}"></div>` : ""}`;
     })
     .join("")}</div></div>`;
+}
+function _renderWaveGantt(waves) {
+  if (!waves || !waves.length) return "";
+  const rowHeight = 28,
+    barHeight = 24,
+    totalHeight = waves.length * rowHeight,
+    byWaveId = Object.fromEntries(waves.map((w, i) => [w.wave_id, { w, i }]));
+  const rows = waves
+    .map((w) => {
+      const total = Number(w.tasks_total || 0),
+        done = Number(w.tasks_done || 0),
+        pct =
+          total > 0
+            ? Math.round((100 * done) / total)
+            : w.status === "done" || w.status === "merging"
+              ? 100
+              : 0,
+        width = Math.max(4, Math.min(100, pct)),
+        statusCls = w.status === "merging" ? "done" : (w.status || "pending"),
+        name = w.name ? ` — ${w.name}` : "";
+      return `<div class="wave-gantt-row" style="height:${rowHeight}px"><div class="wave-gantt-bar wave-gantt-${esc(statusCls)}" style="height:${barHeight}px;width:${width}%"><span><strong>${esc(w.wave_id)}</strong>${esc(name)}</span></div></div>`;
+    })
+    .join("");
+  const arrows = waves
+    .map((w, i) => {
+      const rawDeps = Array.isArray(w.depends_on)
+          ? w.depends_on
+          : typeof w.depends_on === "string"
+            ? w.depends_on
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean)
+            : w.depends_on
+              ? [String(w.depends_on)]
+              : [],
+        dy = i * rowHeight + barHeight / 2;
+      return rawDeps
+        .map((depId) => {
+          const src = byWaveId[depId];
+          if (!src) return "";
+          const swTotal = Number(src.w.tasks_total || 0),
+            swDone = Number(src.w.tasks_done || 0),
+            swPct =
+              swTotal > 0
+                ? Math.round((100 * swDone) / swTotal)
+                : src.w.status === "done" || src.w.status === "merging"
+                  ? 100
+                  : 0,
+            sx = Math.max(4, Math.min(100, swPct)),
+            sy = src.i * rowHeight + barHeight / 2,
+            dx = 0,
+            c1x = Math.min(100, sx + 8),
+            c2x = Math.max(0, dx - 8),
+            stroke =
+              src.w.status === "done" || src.w.status === "merging"
+                ? "var(--green)"
+                : src.w.status === "pending"
+                  ? "var(--text-dim)"
+                  : "var(--cyan)";
+          return `<path class="wave-gantt-arrow" d="M ${sx} ${sy} C ${c1x} ${sy}, ${c2x} ${dy}, ${dx} ${dy}" style="stroke:${stroke}"></path>`;
+        })
+        .join("");
+    })
+    .join("");
+  return `<div class="wave-gantt">${rows}<svg class="wave-gantt-svg" viewBox="0 0 100 ${totalHeight}" preserveAspectRatio="none"><defs><marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6 Z" fill="var(--cyan)"></path></marker></defs>${arrows}</svg></div>`;
 }
 function _healthIcon(code) {
   const icons = {
@@ -87,7 +160,12 @@ window.openPlanTerminal = function (planId, peer) {
   if (typeof termMgr !== "undefined") {
     const session = "plan-" + planId;
     termMgr.open(
-      peer === "local" || peer === "m3max" ? "local" : peer,
+      peer === "local" ||
+        peer ===
+          ((window.DashboardState && window.DashboardState.localPeerName) ||
+            "local")
+        ? "local"
+        : peer,
       "Plan #" + planId,
       session,
     );
@@ -102,7 +180,9 @@ window.resumePlanExecution = function (planId, peer) {
       .find((p) => p.id === planId);
   const assignedHost = planData ? planData.node : peer || "local";
   const target =
-    assignedHost === "local" || assignedHost === "m3max"
+    assignedHost === "local" ||
+    assignedHost ===
+      ((window.DashboardState && window.DashboardState.localPeerName) || "local")
       ? "local"
       : assignedHost;
 
@@ -136,18 +216,18 @@ window.resumePlanExecution = function (planId, peer) {
 function _renderOnePlan(m) {
   const p = m.plan,
     health = m.health || [],
-    pct =
-      p.tasks_total > 0 ? Math.round((100 * p.tasks_done) / p.tasks_total) : 0,
-    ringColor =
-      pct >= 100
-        ? "var(--green)"
-        : pct >= 50
-          ? "var(--cyan)"
-          : pct >= 25
-            ? "var(--gold)"
-            : "var(--red)",
+    rawPct = p.tasks_total > 0 ? Math.round((100 * p.tasks_done) / p.tasks_total) : 0,
+    allValidated = m.waves && m.waves.length && m.waves.every(w => w.validated_at || w.status === "pending"),
+    pct = rawPct >= 100 && !allValidated ? 95 : rawPct,
+    pg = _progressGradient(pct),
+    ringColor = pg.color,
     hostName = p.execution_peer || _resolveHost(p.execution_host),
-    isRemote = hostName && hostName !== "local" && hostName !== "m3max",
+    isRemote =
+      hostName &&
+      hostName !== "local" &&
+      hostName !==
+        ((window.DashboardState && window.DashboardState.localPeerName) ||
+          "local"),
     blocked = (m.tasks || []).filter((t) => t.status === "blocked").length,
     running = (m.tasks || []).filter((t) => t.status === "in_progress").length,
     hasCritical = health.some((h) => h.severity === "critical"),
@@ -156,7 +236,7 @@ function _renderOnePlan(m) {
       : hostName && hostName !== "local"
         ? `<span class="host-badge-local">${esc(hostName)}</span>`
         : "";
-  let html = `<div class="mission-plan${hasCritical ? " mission-plan-critical" : health.length ? " mission-plan-warning" : ""}" onclick="filterTasks(${p.id})"><div style="margin-bottom:6px"><span class="mission-id">#${p.id}</span><span class="mission-name">&nbsp;${esc(p.name)}</span>${statusDot(p.status === "doing" ? "in_progress" : p.status)}${health.length ? `<span class="health-badge health-badge-${hasCritical ? "critical" : "warning"}" title="${health.map((h) => h.message).join("; ")}">${hasCritical ? "ALERT" : "WARN"}</span>` : ""}${nodeLabel}${p.parallel_mode ? `<span class="badge badge-doing">${p.parallel_mode}</span>` : ""}${p.project_name ? `<span class="badge badge-project">${esc(p.project_name)}</span>` : ""}<button class="mission-delegate-btn" onclick="event.stopPropagation();showDelegatePlanDialog(${p.id},'${esc(p.name)}')" title="Delegate to mesh node"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L11 13"/><path d="M22 2L15 22L11 13L2 9L22 2Z"/></svg></button>${p.status === "todo" ? `<button class="mission-start-btn" onclick="event.stopPropagation();showStartPlanDialog(${p.id},'${esc(p.name)}')" title="Start plan execution"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg></button>` : ""}</div>${_renderHealthAlerts(health, p.id, hostName)}${p.human_summary ? `<div class="mission-summary">${esc(p.human_summary)}</div>` : ""}<div class="mission-progress">${_progressRing(pct, 56, ringColor)}<div class="mission-progress-bars"><div class="mission-progress-label"><span>Done ${p.tasks_done || 0}/${p.tasks_total || 0}</span><span style="color:var(--cyan)">${pct}%</span></div><div class="mission-progress-track"><div class="mission-progress-fill" style="width:${pct}%;background:linear-gradient(90deg,${ringColor},var(--cyan))"></div></div><div style="display:flex;gap:12px;font-size:10px;color:var(--text-dim);margin-top:2px"><span>${running > 0 ? `<span style="color:var(--gold)">${running} running</span>` : ""}</span><span>${blocked > 0 ? `<span style="color:var(--red)">${blocked} blocked</span>` : ""}</span></div></div></div>`;
+  let html = `<div class="mission-plan${hasCritical ? " mission-plan-critical" : health.length ? " mission-plan-warning" : ""}" onclick="filterTasks(${p.id})"><div style="margin-bottom:6px"><span class="mission-id">#${p.id}</span><span class="mission-name">&nbsp;${esc(p.name)}</span>${statusDot(p.status === "doing" ? "in_progress" : p.status)}${health.length ? `<span class="health-badge health-badge-${hasCritical ? "critical" : "warning"}" title="${health.map((h) => h.message).join("; ")}">${hasCritical ? "ALERT" : "WARN"}</span>` : ""}${nodeLabel}${p.parallel_mode ? `<span class="badge badge-doing">${p.parallel_mode}</span>` : ""}${p.project_name ? `<span class="badge badge-project">${esc(p.project_name)}</span>` : ""}${p.status === "doing" ? '<button class="btn-brain" onclick="event.stopPropagation();toggleBrainCanvas()">🧠</button>' : ""}<button class="mission-delegate-btn" onclick="event.stopPropagation();showDelegatePlanDialog(${p.id},'${esc(p.name)}')" title="Delegate to mesh node"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L11 13"/><path d="M22 2L15 22L11 13L2 9L22 2Z"/></svg></button>${p.status === "todo" ? `<button class="mission-start-btn" onclick="event.stopPropagation();showStartPlanDialog(${p.id},'${esc(p.name)}')" title="Start plan execution"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5,3 19,12 5,21"/></svg></button>` : ""}</div>${_renderHealthAlerts(health, p.id, hostName)}${p.human_summary ? `<div class="mission-summary">${esc(p.human_summary)}</div>` : ""}<div class="mission-progress">${_progressRing(pct, 56, ringColor)}<div class="mission-progress-bars"><div class="mission-progress-label"><span>Done ${p.tasks_done || 0}/${p.tasks_total || 0}</span><span style="color:var(--cyan)">${pct}%</span></div><div class="mission-progress-track"><div class="mission-progress-fill" style="width:${pct}%;background:${pg.gradient}"></div></div><div style="display:flex;gap:12px;font-size:10px;color:var(--text-dim);margin-top:2px"><span>${running > 0 ? `<span style="color:var(--gold)">${running} running</span>` : ""}</span><span>${blocked > 0 ? `<span style="color:var(--red)">${blocked} blocked</span>` : ""}</span></div></div></div>`;
   if (m.waves && m.waves.length) {
     html += '<div style="margin-top:8px">';
     const activeWaves = m.waves.filter(
@@ -170,21 +250,33 @@ function _renderOnePlan(m) {
           w.tasks_total > 0
             ? Math.round((100 * w.tasks_done) / w.tasks_total)
             : 0,
+        wValidated = !!w.validated_at,
+        wPct = wp >= 100 && !wValidated ? 95 : wp,
+        wg = _progressGradient(wPct),
+        wName = w.name ? ` — ${(w.name || "").substring(0, 35)}` : "",
         cls =
           w.status === "done" || w.status === "merging"
             ? "done"
             : w.status === "in_progress"
               ? "in_progress"
               : "pending";
-      html += `<div class="wave-row"><div class="wave-label">${statusDot(w.status)} ${esc(w.wave_id)}</div><div class="wave-bar"><div class="wave-fill ${cls}" style="width:${wp}%"></div></div><div class="wave-pct">${wp}%</div><div style="margin-left:4px">${thorIcon(w.validated_at)}</div></div>`;
+      html += `<div class="wave-row"><div class="wave-label">${statusDot(w.status)} <strong>${esc(w.wave_id)}</strong><span class="wave-name">${esc(wName)}</span></div><div class="wave-bar"><div class="wave-fill ${cls}" style="width:${wPct}%;background:${wg.gradient}"></div></div><div class="wave-pct" style="color:${wg.color}">${wPct}%</div><div style="margin-left:4px">${thorIcon(w.validated_at)}</div></div>`;
     });
     if (pendingWaves.length > 0) {
       const cid = `pending-waves-${p.id}`;
       html += `<div class="wave-row wave-pending-summary" onclick="event.stopPropagation();document.getElementById('${cid}').classList.toggle('expanded')"><div class="wave-label">${statusDot("pending")} ${pendingWaves.length} waves pending</div><div class="wave-expand-icon">&#9662;</div></div>`;
       html += `<div id="${cid}" class="wave-pending-collapse">`;
       pendingWaves.forEach((w) => {
-        html += `<div class="wave-row wave-row-dim"><div class="wave-label">${statusDot("pending")} ${esc(w.wave_id)}</div><div class="wave-bar"><div class="wave-fill pending" style="width:0%"></div></div><div class="wave-pct">0%</div></div>`;
+        const wName = w.name ? ` — ${(w.name || "").substring(0, 35)}` : "";
+        html += `<div class="wave-row wave-row-dim"><div class="wave-label">${statusDot("pending")} <strong>${esc(w.wave_id)}</strong><span class="wave-name">${esc(wName)}</span></div><div class="wave-bar"><div class="wave-fill pending" style="width:0%"></div></div><div class="wave-pct">0%</div></div>`;
       });
+      html += "</div>";
+    }
+    // Check for dependencies
+    const hasDeps = m.waves && m.waves.some((w) => w.depends_on);
+    if (hasDeps) {
+      html += '<div class="wave-gantt-container">';
+      html += _renderWaveGantt(m.waves);
       html += "</div>";
     }
     html += "</div>";

--- a/scripts/dashboard_web/plan-kanban.js
+++ b/scripts/dashboard_web/plan-kanban.js
@@ -1,0 +1,101 @@
+// Plan Kanban — drag-and-drop plan pipeline (todo → doing → done)
+function renderKanban() {
+  const st = window.DashboardState;
+  if (!st || !st.allMissionPlans) return;
+  const cols = { todo: [], doing: [], done: [] };
+  st.allMissionPlans.forEach((m) => {
+    const p = m.plan;
+    if (!p) return;
+    const s = p.status === "cancelled" ? "done" : (p.status || "todo");
+    if (cols[s]) cols[s].push(m);
+    else cols.todo.push(m);
+  });
+  ["todo", "doing", "done"].forEach((s) => {
+    const el = document.getElementById(`kanban-${s}`);
+    if (!el) return;
+    el.innerHTML = cols[s].map((m) => _kanbanCard(m, s)).join("") ||
+      '<div class="kanban-empty">No plans</div>';
+  });
+}
+
+function _kanbanCard(m, col) {
+  const p = m.plan,
+    pct = p.tasks_total > 0 ? Math.round((100 * p.tasks_done) / p.tasks_total) : 0,
+    running = (m.tasks || []).filter((t) => t.status === "in_progress").length,
+    host = p.execution_peer || p.execution_host || "",
+    rgb = pct >= 75 ? "0,204,106" : pct >= 50 ? "230,161,23" : "238,51,68",
+    border = col === "doing" ? `border-left:3px solid rgba(${rgb},0.8)` : "";
+  return `<div class="kanban-card" draggable="true" data-plan-id="${p.id}" data-status="${p.status}"
+    ondragstart="kanbanDragStart(event)" style="${border}">
+    <div class="kanban-card-top">
+      <span class="kanban-plan-id">#${p.id}</span>
+      <span class="kanban-plan-name">${esc((p.name || "").substring(0, 22))}</span>
+    </div>
+    ${col === "doing" ? `<div class="kanban-progress"><div class="kanban-progress-fill" style="width:${pct}%;background:linear-gradient(90deg,rgba(${rgb},0.6),rgba(${rgb},1))"></div></div>` : ""}
+    <div class="kanban-card-meta">
+      ${p.tasks_done || 0}/${p.tasks_total || 0} tasks
+      ${running > 0 ? `<span class="kanban-running">${running} ⚡</span>` : ""}
+      ${host ? `<span class="kanban-host">${esc(host.substring(0, 10))}</span>` : ""}
+    </div>
+  </div>`;
+}
+
+window.kanbanDragStart = function (e) {
+  e.dataTransfer.setData("text/plain", e.target.dataset.planId);
+  e.dataTransfer.effectAllowed = "move";
+  e.target.classList.add("dragging");
+  setTimeout(() => e.target.classList.remove("dragging"), 0);
+};
+
+window.kanbanDrop = async function (e, targetStatus) {
+  e.preventDefault();
+  e.currentTarget.classList.remove("drag-over");
+  const planId = e.dataTransfer.getData("text/plain");
+  if (!planId) return;
+  const st = window.DashboardState;
+  const m = st.allMissionPlans.find((x) => x.plan && String(x.plan.id) === planId);
+  if (!m) return;
+  const currentStatus = m.plan.status;
+  if (currentStatus === targetStatus) return;
+
+  // Validate transition
+  const valid = {
+    "todo→doing": true,
+    "doing→todo": true,
+    "doing→done": true,
+    "done→todo": true,
+  };
+  const key = `${currentStatus}→${targetStatus}`;
+  if (!valid[key]) {
+    showToast(`Cannot move plan from ${currentStatus} to ${targetStatus}`, "error");
+    return;
+  }
+
+  // Confirm destructive actions
+  if (currentStatus === "doing" && targetStatus === "todo") {
+    if (!confirm(`Stop plan #${planId} and move back to pipeline?`)) return;
+  }
+  if (targetStatus === "done" && currentStatus === "doing") {
+    if (!confirm(`Mark plan #${planId} as complete?`)) return;
+  }
+
+  // Execute via API
+  try {
+    const res = await fetch("/api/plan-status", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plan_id: parseInt(planId, 10), status: targetStatus }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      showToast(data.error, "error");
+      return;
+    }
+    showToast(`Plan #${planId}: ${currentStatus} → ${targetStatus}`, "info");
+    if (typeof refreshAll === "function") refreshAll();
+  } catch (err) {
+    showToast("Failed to update plan status", "error");
+  }
+};
+
+window.renderKanban = renderKanban;

--- a/scripts/dashboard_web/server.py
+++ b/scripts/dashboard_web/server.py
@@ -31,6 +31,7 @@ if __package__ in (None, ""):
         api_tokens_daily,
     )
     from scripts.dashboard_web.api_mesh import (
+        api_mesh_init,
         api_mesh_sync_status,
         handle_mesh_action,
         resolve_host_to_peer,
@@ -88,7 +89,12 @@ else:
         api_tokens_by_model,
         api_tokens_daily,
     )
-    from .api_mesh import api_mesh_sync_status, handle_mesh_action, resolve_host_to_peer
+    from .api_mesh import (
+        api_mesh_init,
+        api_mesh_sync_status,
+        handle_mesh_action,
+        resolve_host_to_peer,
+    )
     from .api_mesh_actions import handle_fullsync_sse, handle_mesh_action_sse
     from .api_peers import (
         api_peer_create,
@@ -227,6 +233,12 @@ class Handler(MiddlewareMixin, SimpleHTTPRequestHandler):
     def do_POST(self):
         parsed = urlparse(self.path)
         path = parsed.path
+        if path == "/api/mesh/init":
+            self._json_response(api_mesh_init())
+            return
+        if path == "/api/plan-status":
+            self._handle_plan_status_change()
+            return
         m = re.match(r"^/api/plans/(\d+)/validate$", path)
         if m:
             self._json_response(handle_plan_validate(int(m.group(1))))
@@ -271,6 +283,29 @@ class Handler(MiddlewareMixin, SimpleHTTPRequestHandler):
 
     def log_message(self, fmt, *args):
         pass
+
+    def _handle_plan_status_change(self):
+        import subprocess
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length)) if length else {}
+        plan_id = body.get("plan_id")
+        target = body.get("status")
+        if not plan_id or target not in ("todo", "doing", "done"):
+            self._json_response({"error": "Invalid plan_id or status"}, 400)
+            return
+        cmd_map = {
+            "doing": ["plan-db.sh", "start", str(plan_id)],
+            "todo": ["plan-db.sh", "update-status", str(plan_id), "todo"],
+            "done": ["plan-db.sh", "complete", str(plan_id)],
+        }
+        try:
+            r = subprocess.run(cmd_map[target], capture_output=True, text=True, timeout=10)
+            if r.returncode != 0:
+                self._json_response({"error": r.stderr.strip() or "Command failed"}, 500)
+                return
+            self._json_response({"ok": True, "plan_id": plan_id, "status": target})
+        except Exception as e:
+            self._json_response({"error": str(e)}, 500)
 
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):

--- a/scripts/dashboard_web/style.css
+++ b/scripts/dashboard_web/style.css
@@ -15,3 +15,6 @@
 @import url('css/components-5.css');
 @import url('css/animations.css');
 @import url('css/peer-crud.css');
+@import url('styles-mission.css');
+@import url('brain-styles.css');
+@import url('kanban-styles.css');

--- a/scripts/dashboard_web/styles-mission.css
+++ b/scripts/dashboard_web/styles-mission.css
@@ -1,0 +1,42 @@
+.wave-name { color: var(--text-dim); font-weight: normal; font-size: 11px; }
+.wave-gantt-container { margin-top: 8px; position: relative; }
+.wave-gantt-bar { height: 24px; border-radius: 4px; margin: 2px 0; position: relative; display: flex; align-items: center; padding: 0 8px; font-size: 10px; }
+.wave-gantt-arrow { stroke: var(--cyan); stroke-width: 1.5; fill: none; marker-end: url(#arrow); }
+
+.wave-gantt {
+  position: relative;
+}
+.wave-gantt-row {
+  display: flex;
+  align-items: center;
+}
+.wave-gantt-bar {
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.wave-gantt-done {
+  background: linear-gradient(90deg, var(--green), #00cc6a);
+}
+.wave-gantt-merging {
+  background: linear-gradient(90deg, var(--green), #00cc6a);
+}
+.wave-gantt-in_progress {
+  background: linear-gradient(90deg, var(--gold), var(--cyan));
+}
+.wave-gantt-pending {
+  background: #3b3f55;
+}
+.wave-gantt-blocked {
+  background: var(--red);
+}
+.wave-gantt-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+}

--- a/scripts/dashboard_web/task-pipeline.js
+++ b/scripts/dashboard_web/task-pipeline.js
@@ -50,8 +50,10 @@ function renderTaskPipeline() {
         const wp =
           w.tasks_total > 0
             ? Math.round((100 * w.tasks_done) / w.tasks_total)
-            : 0;
-        rows += `<tr class="task-wave-header"><td colspan="5">${statusDot(w.status)} <span style="color:var(--text)">${esc(w.wave_id)}</span> <span style="color:var(--text-dim)">${esc((w.name || "").substring(0, 20))}</span> <span style="color:var(--cyan);font-size:10px">${wp}%</span> ${thorIcon(w.validated_at)}</td></tr>`;
+            : 0,
+          wPct = wp >= 100 && !w.validated_at ? 95 : wp,
+          wName = (w.name || "").substring(0, 25);
+        rows += `<tr class="task-wave-header"><td colspan="5">${statusDot(w.status)} <span style="color:var(--text)">${esc(w.wave_id)}</span> <span style="color:var(--text-dim);font-size:10px">${esc(wName)}</span> <span style="color:${wPct >= 75 ? 'var(--green)' : wPct >= 50 ? 'var(--gold)' : 'var(--red)'};font-size:10px">${wPct}%</span> ${thorIcon(w.validated_at)}</td></tr>`;
         waveTasks.forEach((t) => (rows += _taskRow(t)));
       });
       tasks

--- a/scripts/dashboard_web/websocket.js
+++ b/scripts/dashboard_web/websocket.js
@@ -35,7 +35,18 @@ function _meshNodeHtml(p) {
     memPct =
       memTotal > 0 ? Math.min(Math.round((100 * memUsed) / memTotal), 100) : 0,
     memColor =
-      memPct < 60 ? "var(--green)" : memPct < 85 ? "var(--gold)" : "var(--red)";
+      memPct < 60 ? "var(--green)" : memPct < 85 ? "var(--gold)" : "var(--red)",
+    peerKey = (p.peer_name || "unknown").replace(/[^a-zA-Z0-9]/g, "_");
+  // Track history for sparklines (last 30 samples)
+  if (!window._meshHistory) window._meshHistory = {};
+  if (!window._meshHistory[peerKey]) window._meshHistory[peerKey] = { cpu: [], mem: [] };
+  const hist = window._meshHistory[peerKey];
+  if (p.is_online) {
+    hist.cpu.push(loadPct);
+    hist.mem.push(memPct);
+    if (hist.cpu.length > 30) hist.cpu.shift();
+    if (hist.mem.length > 30) hist.mem.shift();
+  }
   let planHtml = "";
   (p.plans || []).forEach((pl) => {
     const pp =
@@ -53,7 +64,55 @@ function _meshNodeHtml(p) {
   const actions = p.is_online
     ? `<div class="mn-actions">${a("terminal", "Terminal", '<rect x="2" y="3" width="12" height="10" rx="1.5"/><path d="M4.5 7l2 1.5-2 1.5M8 10.5h3"/>')}${a("sync", "Sync", '<path d="M1.5 8a6.5 6.5 0 0112.4-2.5M14.5 8a6.5 6.5 0 01-12.4 2.5"/><path d="M13 2.5v3h-3M3 13.5v-3h3"/>')}${a("heartbeat", "Heartbeat", '<path d="M2 8h2l1.5-3 2 6 2-4.5 1.5 1.5h3"/>')}${a("auth", "Auth", '<rect x="4" y="7" width="8" height="6" rx="1"/><path d="M6 7V5a2 2 0 014 0v2"/><circle cx="8" cy="10" r="0.5"/>')}${a("status", "Status", '<circle cx="8" cy="8" r="5.5"/><path d="M8 5v3.5l2.5 1.5"/>')}${a("movehere", "Move Here", '<path d="M3 8h10M10 5l3 3-3 3"/>')}${a("reboot", "Reboot", '<path d="M8 2v4M4.5 4.2A5.5 5.5 0 108 2.5"/>')}</div>`
     : `<div class="mn-actions">${a("wake", "Wake (WoL)", '<circle cx="8" cy="8" r="5.5" fill="none"/><path d="M8 5v3M8 10v0.5"/>')}</div>`;
-  return `<div class="${cls}" data-peer="${esc(p.peer_name)}"><div class="mn-top"><span class="mn-os">${OS_ICON[p.os] || OS_ICON.unknown}</span><span class="mn-name">${esc(p.peer_name)}</span><span class="mn-dot ${p.is_online ? "on" : "off"}"></span></div><div class="mn-role">${p.role.toUpperCase()}${p.is_local ? " · LOCAL" : ""}</div><div class="mn-caps">${caps.map((c) => `<span class="mn-cap${c === "ollama" ? " accent" : ""}">${c}</span>`).join("")}</div>${p.is_online ? `<div class="mn-stats">${p.active_tasks} tasks · CPU ${Math.round(p.cpu)}%${memTotal > 0 ? ` · RAM ${memUsed.toFixed(1)}/${memTotal.toFixed(0)}GB` : ""}</div><div class="mn-gauges"><div class="mn-gauge-group"><span class="mn-gauge-label">CPU</span><div class="mn-load-bar"><div class="mn-load-fill" style="width:${loadPct}%;background:${loadColor}"></div></div><span class="mn-gauge-val">${Math.round(loadPct)}%</span></div>${memTotal > 0 ? `<div class="mn-gauge-group"><span class="mn-gauge-label">RAM</span><div class="mn-load-bar"><div class="mn-load-fill" style="width:${memPct}%;background:${memColor}"></div></div><span class="mn-gauge-val">${memPct}%</span></div>` : ""}</div>` : '<div class="mn-stats offline-text">No heartbeat</div>'}${planHtml}${actions}</div>`;
+  return `<div class="${cls}" data-peer="${esc(p.peer_name)}"><div class="mn-top"><span class="mn-os">${OS_ICON[p.os] || OS_ICON.unknown}</span><span class="mn-name">${esc(p.peer_name)}</span><span class="mn-dot ${p.is_online ? "on" : "off"}"></span></div><div class="mn-role">${p.role.toUpperCase()}${p.is_local ? " · LOCAL" : ""}</div><div class="mn-caps">${caps.map((c) => `<span class="mn-cap${c === "ollama" ? " accent" : ""}">${c}</span>`).join("")}</div>${p.is_online ? `<div class="mn-stats">${p.active_tasks} tasks · CPU ${Math.round(p.cpu)}%${memTotal > 0 ? ` · RAM ${memUsed.toFixed(1)}/${memTotal.toFixed(0)}GB` : ""}</div><div class="mn-gauges"><div class="mn-gauge-group"><span class="mn-gauge-label">CPU</span><canvas id="spark-cpu-${peerKey}" class="mn-sparkline" width="120" height="28" data-history="${hist.cpu.join(",")}" data-color="${loadColor}" data-pct="${loadPct}"></canvas><span class="mn-gauge-val" style="color:${loadColor}">${Math.round(loadPct)}%</span></div>${memTotal > 0 ? `<div class="mn-gauge-group"><span class="mn-gauge-label">RAM</span><canvas id="spark-mem-${peerKey}" class="mn-sparkline" width="120" height="28" data-history="${hist.mem.join(",")}" data-color="${memColor}" data-pct="${memPct}"></canvas><span class="mn-gauge-val" style="color:${memColor}">${memPct}%</span></div>` : ""}</div>` : '<div class="mn-stats offline-text">No heartbeat</div>'}${planHtml}${actions}</div>`;
+}
+function _drawSparklines() {
+  document.querySelectorAll(".mn-sparkline").forEach((c) => {
+    const ctx = c.getContext("2d");
+    if (!ctx) return;
+    const w = c.width, h = c.height,
+      data = (c.dataset.history || "").split(",").map(Number).filter((v) => !isNaN(v)),
+      color = c.dataset.color || "var(--cyan)",
+      pct = parseFloat(c.dataset.pct) || 0;
+    ctx.clearRect(0, 0, w, h);
+    if (data.length < 2) {
+      // Single bar fallback
+      const rgb = pct < 50 ? "0,204,106" : pct < 80 ? "230,161,23" : "238,51,68";
+      ctx.fillStyle = `rgba(${rgb},0.3)`;
+      ctx.fillRect(0, h - (pct / 100) * h, w, (pct / 100) * h);
+      ctx.fillStyle = `rgba(${rgb},0.8)`;
+      ctx.fillRect(w - 3, h - (pct / 100) * h, 3, (pct / 100) * h);
+      return;
+    }
+    const max = 100, step = w / (data.length - 1);
+    // Fill gradient under the line
+    const grad = ctx.createLinearGradient(0, 0, 0, h);
+    const rgb = pct < 50 ? "0,204,106" : pct < 80 ? "230,161,23" : "238,51,68";
+    grad.addColorStop(0, `rgba(${rgb},0.25)`);
+    grad.addColorStop(1, `rgba(${rgb},0.02)`);
+    ctx.beginPath();
+    ctx.moveTo(0, h);
+    data.forEach((v, i) => ctx.lineTo(i * step, h - (v / max) * h));
+    ctx.lineTo((data.length - 1) * step, h);
+    ctx.closePath();
+    ctx.fillStyle = grad;
+    ctx.fill();
+    // Line
+    ctx.beginPath();
+    data.forEach((v, i) => {
+      const x = i * step, y = h - (v / max) * h;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = `rgba(${rgb},0.9)`;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+    // Current value dot
+    const lastX = (data.length - 1) * step, lastY = h - (data[data.length - 1] / max) * h;
+    ctx.beginPath();
+    ctx.arc(lastX, lastY, 2.5, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(${rgb},1)`;
+    ctx.fill();
+  });
 }
 function _drawSpokes() {
   const c = document.getElementById("mesh-spokes");
@@ -99,7 +158,7 @@ function renderMeshStrip(peers) {
     el.innerHTML = `<div class="mesh-hub"><div class="mesh-hub-workers">${workers.map(_meshNodeHtml).join("")}</div><div class="mesh-hub-spokes" id="mesh-spokes"></div><div class="mesh-hub-coord">${_meshNodeHtml(coord)}</div></div>`;
   } else
     el.innerHTML = `<div class="mesh-nodes">${peers.map(_meshNodeHtml).join("")}</div>`;
-  requestAnimationFrame(_drawSpokes);
+  requestAnimationFrame(() => { _drawSpokes(); _drawSparklines(); });
 }
 function applyMeshSyncBadges(items) {
   if (!items || !items.length) return;

--- a/scripts/lib/mesh-env-tools.sh
+++ b/scripts/lib/mesh-env-tools.sh
@@ -14,15 +14,24 @@ _skip() { echo "[mesh-env] SKIP: $*"; }
 
 # ---- OS detection ------------------------------------------------------------
 detect_os() {
-	if [[ "$(uname -s)" == "Darwin" ]]; then
-		echo "macos"
-	elif [[ -f /etc/debian_version ]]; then
-		echo "debian"
-	elif [[ -f /etc/redhat-release ]]; then
-		echo "redhat"
-	else
-		echo "unknown"
-	fi
+	local uname_s
+	uname_s="$(uname -s 2>/dev/null || echo "Unknown")"
+	case "$uname_s" in
+		Darwin) echo "macos" ;;
+		Linux)
+			if grep -qi microsoft /proc/version 2>/dev/null; then
+				echo "windows" # WSL
+			elif [[ -f /etc/debian_version ]]; then
+				echo "debian"
+			elif [[ -f /etc/redhat-release ]]; then
+				echo "redhat"
+			else
+				echo "linux"
+			fi
+			;;
+		MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+		*) echo "unknown" ;;
+	esac
 }
 
 # ---- package install helpers -------------------------------------------------

--- a/scripts/lib/mesh-migrate-sync.sh
+++ b/scripts/lib/mesh-migrate-sync.sh
@@ -95,11 +95,19 @@ _migrate_rsync() {
 	local src="$2"
 	local remote="$3"
 
-	rsync -avz --progress --delete \
-		--exclude-from="$EXCLUDE_FILE" \
-		-e "ssh $SSH_OPTS" \
-		"$src" "${dest}:${remote}"
+	_sync_files "$src" "$dest" "$remote"
 	return $?
+}
+
+_sync_files() {
+	local src="$1" dest_host="$2" dest_path="$3"
+	if command -v rsync &>/dev/null; then
+		rsync -avz --progress --delete --exclude-from="$EXCLUDE_FILE" -e "ssh $SSH_OPTS" "$src" "${dest_host}:${dest_path}"
+	else
+		# Fallback: tar + ssh (works on Windows with OpenSSH)
+		tar czf - --exclude-from="$EXCLUDE_FILE" -C "$(dirname "$src")" "$(basename "$src")" |
+			ssh $SSH_OPTS "$dest_host" "cd $(dirname "$dest_path") && tar xzf -"
+	fi
 }
 
 # Sync all relevant paths to target

--- a/scripts/lib/peers.sh
+++ b/scripts/lib/peers.sh
@@ -179,3 +179,15 @@ peers_others() {
 		[[ "$name" != "$self" ]] && echo "$name"
 	done
 }
+
+# Translate Unix path to Windows path for remote commands
+_remote_claude_home() {
+	local peer="$1"
+	local os
+	os="$(peers_get "$peer" "os" 2>/dev/null || echo "linux")"
+	if [[ "$os" == "windows" ]]; then
+		echo '%USERPROFILE%\.claude'
+	else
+		echo '~/.claude'
+	fi
+}

--- a/scripts/lib/plan-db-core.sh
+++ b/scripts/lib/plan-db-core.sh
@@ -7,9 +7,12 @@ DB_FILE="${HOME}/.claude/data/dashboard.db"
 AUDIT_LOG="${AUDIT_LOG:-${HOME}/.claude/data/thor-audit.jsonl}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Export hostname for distributed execution tracking
-# Strip .local suffix for consistency (macOS hostname vs DB stored values)
-PLAN_DB_HOST="${HOSTNAME:-$(hostname -s 2>/dev/null || hostname)}"
+# Resolve canonical peer name via Tailscale IP match (stable across hostname changes)
+if [[ -f "$SCRIPT_DIR/lib/peers.sh" ]] && ! declare -F peers_self &>/dev/null; then
+	source "$SCRIPT_DIR/lib/peers.sh"
+	peers_load 2>/dev/null || true
+fi
+PLAN_DB_HOST="$(peers_self 2>/dev/null || hostname -s 2>/dev/null || hostname)"
 export PLAN_DB_HOST="${PLAN_DB_HOST%.local}"
 
 # Colors

--- a/scripts/lib/plan-db-remote.sh
+++ b/scripts/lib/plan-db-remote.sh
@@ -53,9 +53,9 @@ cmd_cluster_status() {
 	if ssh -o ConnectTimeout="${PLAN_DB_SSH_TIMEOUT:-5}" -o BatchMode=yes "$REMOTE_HOST" "echo ok" &>/dev/null; then
 		remote_online=1
 		remote_plans=$(ssh -o ConnectTimeout=10 "$REMOTE_HOST" "
-			sqlite3 -separator '|' ~/.claude/data/dashboard.db \"
-				SELECT p.id, p.name, p.tasks_done || '/' || p.tasks_total,
-				       COALESCE(p.execution_host, '$(hostname -s)'), p.status
+				sqlite3 -separator '|' ~/.claude/data/dashboard.db \"
+					SELECT p.id, p.name, p.tasks_done || '/' || p.tasks_total,
+					       COALESCE(p.execution_host, '$PLAN_DB_HOST'), p.status
 				FROM plans p WHERE p.status IN ('doing','todo')
 				ORDER BY p.status, p.id;
 			\"

--- a/scripts/mesh-coordinator.sh
+++ b/scripts/mesh-coordinator.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# mesh-coordinator.sh — Event-driven coordinator daemon for m3max (master node).
+# mesh-coordinator.sh — Event-driven coordinator daemon for coordinator node.
 # Processes mesh_events, handles auto-finish, offline detection, auto-reassign.
 # Usage: mesh-coordinator.sh [start|stop|status|run-once|--help]
 set -euo pipefail
@@ -13,6 +13,7 @@ INTERVAL=15
 OFFLINE_THRESHOLD=900   # 15 min
 REASSIGN_THRESHOLD=1800 # 30 min
 REASSIGN_GRACE=2        # cycles before reassign
+SCRIPT_MTIME="$(stat -f %m "$0" 2>/dev/null || stat -c %Y "$0" 2>/dev/null || echo 0)"
 
 source "$SCRIPT_DIR/lib/peers.sh"
 source "$SCRIPT_DIR/lib/notify-config.sh"
@@ -134,12 +135,21 @@ _check_offline_nodes() {
 		[[ -f "$counter_file" ]] && count=$(cat "$counter_file" 2>/dev/null || echo "0")
 		count=$((count + 1))
 		echo "$count" >"$counter_file"
+		# Cap: once past grace + 1, stop logging (notification already sent)
+		if [[ $count -gt $((REASSIGN_GRACE + 1)) ]]; then
+			continue
+		fi
 		# First detection: warn. After grace: notify critical (but NEVER reassign)
 		if [[ $count -le 1 ]]; then
 			_warn "Node $peer_name offline (${age}s). Plans affected: $(echo "$active_plans" | tr '\n' ',' | sed 's/,$//')"
 		elif [[ $count -eq $REASSIGN_GRACE ]]; then
 			while IFS= read -r pid; do
 				[[ -z "$pid" ]] && continue
+				local current_host
+				current_host=$(_db "SELECT execution_host FROM plans WHERE id=$pid;")
+				if [[ -n "$current_host" && "$current_host" != "$peer_name" ]]; then
+					continue # already reassigned
+				fi
 				_notify critical "Node $peer_name offline" \
 					"Plan #$pid needs manual reassignment (use dashboard Delegate or mesh-migrate.sh)" \
 					--link "http://localhost:8420/#plan/$pid" --plan-id "$pid"
@@ -155,17 +165,23 @@ _check_offline_nodes() {
 	done < <(_db "SELECT peer_name, last_seen FROM peer_heartbeats;")
 }
 
-# Single coordinator cycle
-_run_once() {
-	_process_events
-	_check_offline_nodes
+_run_once() { _process_events; _check_offline_nodes; }
+
+_check_script_update() {
+	local current_mtime="$(stat -f %m "${BASH_SOURCE[0]}" 2>/dev/null || stat -c %Y "${BASH_SOURCE[0]}" 2>/dev/null || echo 0)"
+	[[ "$current_mtime" == "$SCRIPT_MTIME" ]] && return 0
+	_info "Script updated (mtime $SCRIPT_MTIME → $current_mtime), restarting..."
+	exec "$0" start
 }
 
 # Daemon loop
 _daemon_loop() {
+	local cycle_count=0
 	_info "Coordinator started (interval: ${INTERVAL}s)"
 	while true; do
+		cycle_count=$((cycle_count + 1))
 		_run_once 2>>"$LOG_FILE" || true
+		((cycle_count % 10 == 0)) && _check_script_update
 		sleep "$INTERVAL"
 	done
 }

--- a/scripts/mesh-db-sync-tasks.sh
+++ b/scripts/mesh-db-sync-tasks.sh
@@ -76,19 +76,22 @@ _pull_from_peer() {
 	local plan_sql="SELECT p.id,p.tasks_done,p.tasks_total,p.status FROM plans p WHERE $plan_where;"
 
 	local hb_sql="SELECT peer_name,last_seen,load_json,capabilities FROM peer_heartbeats;"
+	local remote_claude_home remote_db
+	remote_claude_home="$(_remote_claude_home "$peer")"
+	remote_db="${remote_claude_home}/data/dashboard.db"
 
 	local remote_data
-	remote_data="$(_ssh "$peer" "sqlite3 ~/.claude/data/dashboard.db '.timeout 3000' \
+	remote_data="$(_ssh "$peer" "sqlite3 ${remote_db} '.timeout 3000' \
     '.separator |' \
     \"$remote_sql\" \
     2>/dev/null; echo '===WAVES==='; \
-    sqlite3 ~/.claude/data/dashboard.db '.timeout 3000' '.separator |' \
+    sqlite3 ${remote_db} '.timeout 3000' '.separator |' \
     \"$wave_sql\" 2>/dev/null; \
     echo '===PLANS==='; \
-    sqlite3 ~/.claude/data/dashboard.db '.timeout 3000' '.separator |' \
+    sqlite3 ${remote_db} '.timeout 3000' '.separator |' \
     \"$plan_sql\" 2>/dev/null; \
     echo '===HEARTBEATS==='; \
-    sqlite3 ~/.claude/data/dashboard.db '.timeout 3000' '.separator |' \
+    sqlite3 ${remote_db} '.timeout 3000' '.separator |' \
     \"$hb_sql\" 2>/dev/null")" || {
 		warn "$peer: SSH failed"
 		return 1

--- a/scripts/mesh-discover.sh
+++ b/scripts/mesh-discover.sh
@@ -72,7 +72,7 @@ while IFS= read -r line; do
 	[[ -z "${line// /}" ]] && continue
 
 	if [[ "$line" =~ ^\[(.+)\]$ ]]; then
-		[[ -n "${PEER_NAME:-}" && -n "${PEER_SSH:-}" && "${PEER_STATUS:-active}" == "active" && "$PEER_NAME" != "m3max" ]] && {
+		[[ -n "${PEER_NAME:-}" && -n "${PEER_SSH:-}" && "${PEER_STATUS:-active}" == "active" && "$PEER_NAME" != "$(peers_self 2>/dev/null || hostname -s)" ]] && {
 			echo ""
 			echo "--- $PEER_NAME ($PEER_SSH) ---"
 			if ssh -o ConnectTimeout=5 -o BatchMode=yes "$PEER_SSH" true 2>/dev/null; then
@@ -104,7 +104,7 @@ while IFS= read -r line; do
 done <"$PEERS_CONF"
 
 # Emit last peer
-[[ -n "${PEER_NAME:-}" && -n "${PEER_SSH:-}" && "${PEER_STATUS:-active}" == "active" && "$PEER_NAME" != "m3max" ]] && {
+[[ -n "${PEER_NAME:-}" && -n "${PEER_SSH:-}" && "${PEER_STATUS:-active}" == "active" && "$PEER_NAME" != "$(peers_self 2>/dev/null || hostname -s)" ]] && {
 	echo ""
 	echo "--- $PEER_NAME ($PEER_SSH) ---"
 	if ssh -o ConnectTimeout=5 -o BatchMode=yes "$PEER_SSH" true 2>/dev/null; then

--- a/scripts/mesh-heartbeat.sh
+++ b/scripts/mesh-heartbeat.sh
@@ -148,6 +148,12 @@ _daemon_loop() {
 # Commands
 
 cmd_start() {
+	if [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* ]]; then
+		info "Windows detected. Use Task Scheduler instead:"
+		info "  schtasks /create /tn 'MeshHeartbeat' /tr 'bash -c \"$0 run-once\"' /sc minute /mo 1"
+		exit 0
+	fi
+
 	if [[ -f "$PID_FILE" ]]; then
 		local old_pid
 		old_pid="$(cat "$PID_FILE" 2>/dev/null || echo "")"

--- a/scripts/mesh-load-query.sh
+++ b/scripts/mesh-load-query.sh
@@ -112,8 +112,17 @@ _privacy_safe_for_caps() {
 _remote_cmd() {
 	cat <<'REMOTE'
 set +e
-# uptime: macOS -> "load averages: X Y Z" | Linux -> "load average: X, Y, Z"
-cpu=$(uptime 2>/dev/null | sed -E 's/.*load averages?: *([0-9]+\.[0-9]+).*/\1/')
+cpu=0
+if [ "$(uname)" = "Darwin" ]; then
+  # macOS load average
+  cpu=$(uptime 2>/dev/null | sed -E 's/.*load averages?: *([0-9]+\.[0-9]+).*/\1/')
+elif [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* || "$(uname -s)" == CYGWIN* ]]; then
+  # Windows: use PowerShell
+  cpu="$(powershell.exe -NoProfile -Command '(Get-CimInstance Win32_Processor).LoadPercentage' 2>/dev/null || echo 0)"
+else
+  # Linux load average
+  cpu=$(uptime 2>/dev/null | sed -E 's/.*load averages?: *([0-9]+\.[0-9]+).*/\1/')
+fi
 db="$HOME/.claude/data/dashboard.db"
 tasks=0
 if [ -f "$db" ] && command -v sqlite3 >/dev/null 2>&1; then
@@ -130,6 +139,11 @@ if [ "$(uname)" = "Darwin" ]; then
   total_bytes=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
   used_bytes=$(( total_bytes - free_bytes ))
   mem_used=$(echo "$used_bytes" | awk '{printf "%.1f", $1/1073741824}')
+elif [[ "$(uname -s)" == MINGW* || "$(uname -s)" == MSYS* || "$(uname -s)" == CYGWIN* ]]; then
+  # Windows: use PowerShell
+  mem_info="$(powershell.exe -NoProfile -Command '$os=Get-CimInstance Win32_OperatingSystem; "{0}|{1}" -f [math]::Round(($os.TotalVisibleMemorySize-$os.FreePhysicalMemory)/1MB,1), [math]::Round($os.TotalVisibleMemorySize/1MB,1)' 2>/dev/null || echo '0|0')"
+  mem_used="${mem_info%%|*}"
+  mem_total="${mem_info##*|}"
 else
   mem_total=$(awk '/MemTotal/ {printf "%.1f", $2/1048576}' /proc/meminfo 2>/dev/null)
   mem_avail=$(awk '/MemAvailable/ {printf "%.1f", $2/1048576}' /proc/meminfo 2>/dev/null)
@@ -137,6 +151,26 @@ else
 fi
 printf '%s %s %s %s\n' "${cpu:-0}" "${tasks:-0}" "${mem_used:-0}" "${mem_total:-0}"
 REMOTE
+}
+
+_ssh() {
+	local peer="$1"
+	shift
+	local target user dest
+	target="$(peers_best_route "$peer" 2>/dev/null)" || return 1
+	user="$(peers_get "$peer" "user" 2>/dev/null || echo "")"
+	dest="${user:+${user}@}${target}"
+	ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new \
+		-o BatchMode=yes -o LogLevel=quiet "$dest" "$@" 2>/dev/null
+}
+
+_get_remote_load() {
+	local peer="$1" os="$2"
+	if [[ "$os" == "windows" ]]; then
+		_ssh "$peer" "powershell.exe -NoProfile -Command '(Get-CimInstance Win32_Processor).LoadPercentage'"
+	else
+		_ssh "$peer" "uptime | grep -oE 'load averages?: [0-9]+\\.[0-9]+' | grep -oE '[0-9]+\\.[0-9]+$'"
+	fi
 }
 
 _upsert_heartbeat() {
@@ -161,28 +195,30 @@ _write_offline() {
 
 _query_peer() {
 	local name="$1" result_file="$2"
-	local caps cost_tier privacy_safe
+	local caps cost_tier privacy_safe os
 	caps="$(peers_get "$name" "capabilities" 2>/dev/null || echo "")"
 	cost_tier="$(_cost_tier_for_caps "$caps")"
 	privacy_safe="$(_privacy_safe_for_caps "$caps")"
+	os="$(peers_get "$name" "os" 2>/dev/null || echo "linux")"
 
-	local target user dest
-	target="$(peers_best_route "$name" 2>/dev/null)" || {
-		_write_offline "$name" "$caps" "$cost_tier" "$privacy_safe" "$result_file"
-		return
-	}
-	user="$(peers_get "$name" "user" 2>/dev/null || echo "")"
-	dest="${user:+${user}@}${target}"
-
-	local raw
-	if ! raw="$(ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new \
-		-o BatchMode=yes -o LogLevel=quiet \
-		"$dest" "bash -s" <<<"$(_remote_cmd)" 2>/dev/null)"; then
+	if ! peers_best_route "$name" >/dev/null 2>&1; then
 		_write_offline "$name" "$caps" "$cost_tier" "$privacy_safe" "$result_file"
 		return
 	fi
 
-	local cpu tasks mem_used mem_total
+	local raw cpu tasks mem_used mem_total mem_info
+	if [[ "$os" == "windows" ]]; then
+		cpu="$(_get_remote_load "$name" "$os" || echo "0")"
+		mem_info="$(_ssh "$name" "powershell.exe -NoProfile -Command '\$os=Get-CimInstance Win32_OperatingSystem; \"{0}|{1}\" -f [math]::Round((\$os.TotalVisibleMemorySize-\$os.FreePhysicalMemory)/1MB,1), [math]::Round(\$os.TotalVisibleMemorySize/1MB,1)'" || echo "0|0")"
+		mem_used="${mem_info%%|*}"
+		mem_total="${mem_info##*|}"
+		tasks="$(_ssh "$name" "powershell.exe -NoProfile -Command '\$db=Join-Path \$env:USERPROFILE ''.claude\\data\\dashboard.db''; if (Test-Path \$db -and (Get-Command sqlite3 -ErrorAction SilentlyContinue)) { sqlite3 \$db \"SELECT COUNT(*) FROM tasks WHERE status=''in_progress'';\" } else { 0 }'" || echo "0")"
+		raw="${cpu:-0} ${tasks:-0} ${mem_used:-0} ${mem_total:-0}"
+	elif ! raw="$(_ssh "$name" "bash -s" <<<"$(_remote_cmd)")"; then
+		_write_offline "$name" "$caps" "$cost_tier" "$privacy_safe" "$result_file"
+		return
+	fi
+
 	cpu="$(echo "$raw" | awk '{print $1}')"
 	tasks="$(echo "$raw" | awk '{print $2}')"
 	mem_used="$(echo "$raw" | awk '{print $3}')"

--- a/scripts/mesh-normalize-hosts.sh
+++ b/scripts/mesh-normalize-hosts.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_HOME="${CLAUDE_HOME:-$HOME/.claude}"
+DB_PATH="${CLAUDE_DB:-${PLAN_DB_FILE:-$CLAUDE_HOME/data/dashboard.db}}"
+DRY_RUN=false
+
+usage() {
+  cat <<'USAGE'
+Usage: mesh-normalize-hosts.sh [--dry-run]
+
+One-time migration that normalizes plans.execution_host and tasks.executor_host
+using canonical peer names from peers.conf.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "ERROR: Database not found: $DB_PATH" >&2
+  exit 1
+fi
+
+# shellcheck source=scripts/lib/peers.sh
+source "$SCRIPT_DIR/lib/peers.sh"
+peers_load
+
+sql_quote() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf "%s" "$s"
+}
+
+SQL_FILE="$(mktemp)"
+trap 'rm -f "$SQL_FILE"' EXIT
+
+{
+  echo "BEGIN IMMEDIATE;"
+  echo "CREATE TEMP TABLE host_map (variant TEXT PRIMARY KEY, canonical TEXT NOT NULL);"
+} >"$SQL_FILE"
+
+add_variant() {
+  local canonical="$1"
+  local variant_raw="$2"
+  local variant
+  variant="$(trim "$variant_raw")"
+  [[ -z "$canonical" || -z "$variant" ]] && return 0
+
+  local q_canonical q_variant
+  q_canonical="$(sql_quote "$canonical")"
+  q_variant="$(sql_quote "$variant")"
+  printf "INSERT OR IGNORE INTO host_map(variant, canonical) VALUES ('%s', '%s');\n" \
+    "$q_variant" "$q_canonical" >>"$SQL_FILE"
+}
+
+# Build peer variants -> canonical mapping for each section in peers.conf
+for peer in $_PEERS_ALL; do
+  add_variant "$peer" "$peer"
+  add_variant "$peer" "$(peers_get "$peer" ssh_alias 2>/dev/null || true)"
+  add_variant "$peer" "$(peers_get "$peer" dns_name 2>/dev/null || true)"
+done
+
+# Local machine historical variants -> peers_self canonical name
+SELF_PEER="$(peers_self || true)"
+if [[ -n "$SELF_PEER" ]]; then
+  HN_SHORT="$(hostname -s 2>/dev/null || true)"
+  HN_FULL="$(hostname 2>/dev/null || true)"
+  LOCAL_HOSTNAME="$(scutil --get LocalHostName 2>/dev/null || true)"
+  COMPUTER_NAME="$(scutil --get ComputerName 2>/dev/null | tr -d "'" || true)"
+
+  add_variant "$SELF_PEER" "$HN_SHORT"
+  add_variant "$SELF_PEER" "$HN_FULL"
+  add_variant "$SELF_PEER" "$LOCAL_HOSTNAME"
+  add_variant "$SELF_PEER" "$COMPUTER_NAME"
+
+  # Common macOS DNS-style variants seen historically
+  [[ -n "$HN_SHORT" ]] && add_variant "$SELF_PEER" "${HN_SHORT}.lan"
+  [[ -n "$LOCAL_HOSTNAME" ]] && add_variant "$SELF_PEER" "${LOCAL_HOSTNAME}.lan"
+  [[ -n "$COMPUTER_NAME" ]] && add_variant "$SELF_PEER" "${COMPUTER_NAME}.lan"
+fi
+
+cat >>"$SQL_FILE" <<'SQL'
+CREATE TEMP TABLE _counts(name TEXT PRIMARY KEY, value INTEGER);
+
+UPDATE plans
+SET execution_host = (SELECT m.canonical FROM host_map m WHERE m.variant = plans.execution_host)
+WHERE execution_host IN (SELECT variant FROM host_map)
+  AND execution_host <> (SELECT m.canonical FROM host_map m WHERE m.variant = plans.execution_host);
+INSERT INTO _counts(name, value) VALUES ('plans', changes());
+
+UPDATE tasks
+SET executor_host = (SELECT m.canonical FROM host_map m WHERE m.variant = tasks.executor_host)
+WHERE executor_host IN (SELECT variant FROM host_map)
+  AND executor_host <> (SELECT m.canonical FROM host_map m WHERE m.variant = tasks.executor_host);
+INSERT INTO _counts(name, value) VALUES ('tasks', changes());
+
+DELETE FROM peer_heartbeats
+WHERE peer_name LIKE 'test-%';
+INSERT INTO _counts(name, value) VALUES ('heartbeats', changes());
+
+SELECT
+  COALESCE((SELECT value FROM _counts WHERE name='plans'), 0) || '|' ||
+  COALESCE((SELECT value FROM _counts WHERE name='tasks'), 0) || '|' ||
+  COALESCE((SELECT value FROM _counts WHERE name='heartbeats'), 0);
+COMMIT;
+SQL
+
+if $DRY_RUN; then
+  cat "$SQL_FILE"
+  exit 0
+fi
+
+result="$(sqlite3 -batch "$DB_PATH" <"$SQL_FILE")"
+IFS='|' read -r plans_count tasks_count heartbeats_count <<<"$result"
+
+echo "Normalized ${plans_count:-0} plans, ${tasks_count:-0} tasks. Cleaned ${heartbeats_count:-0} test heartbeats."

--- a/scripts/mesh-sync-config.sh
+++ b/scripts/mesh-sync-config.sh
@@ -74,7 +74,7 @@ while IFS='|' read -r name ssh_alias user <&3 || [[ -n "$name" ]]; do
 	[[ -z "$name" ]] && continue
 
 	# Skip self (coordinator)
-	if [[ "$name" == "m3max" ]]; then
+	if [[ "$name" == "$(peers_self 2>/dev/null || hostname -s)" ]]; then
 		inc SKIPPED
 		continue
 	fi

--- a/scripts/plan-db.sh
+++ b/scripts/plan-db.sh
@@ -44,7 +44,10 @@ source "$SCRIPT_DIR/lib/plan-db-intelligence.sh"
 [[ -f "$SCRIPT_DIR/lib/plan-db-knowledge.sh" ]] && source "$SCRIPT_DIR/lib/plan-db-knowledge.sh"
 
 # Host identification for cross-machine tracking
-export PLAN_DB_HOST="${PLAN_DB_HOST:-$(hostname -s 2>/dev/null || hostname)}"
+if [[ -z "${PLAN_DB_HOST:-}" ]]; then
+	PLAN_DB_HOST="$(peers_self 2>/dev/null || hostname -s 2>/dev/null || hostname)"
+fi
+export PLAN_DB_HOST
 
 # Initialize DB
 init_db

--- a/tests/test-mesh-concurrency.sh
+++ b/tests/test-mesh-concurrency.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$REPO_ROOT/tests/lib/test-helpers.sh"
+
+SCORING_LIB="$REPO_ROOT/scripts/lib/mesh-scoring.sh"
+
+setup() {
+  export TEST_DB
+  TEST_DB=$(mktemp /tmp/test-concurrency-XXXXXX.db)
+  export TEST_TMP_DIR
+  TEST_TMP_DIR=$(mktemp -d /tmp/test-concurrency-bin-XXXXXX)
+
+  sqlite3 "$TEST_DB" "
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE peer_heartbeats(
+      peer_name TEXT PRIMARY KEY,
+      status TEXT,
+      last_seen TEXT,
+      cpu_load REAL,
+      mem_used_gb REAL,
+      mem_total_gb REAL,
+      tasks_in_progress INTEGER DEFAULT 0,
+      cost_tier TEXT DEFAULT 'free'
+    );
+    CREATE TABLE plans(id INTEGER PRIMARY KEY, status TEXT DEFAULT 'doing');
+    CREATE TABLE waves(id INTEGER PRIMARY KEY, plan_id INTEGER, status TEXT DEFAULT 'pending');
+    CREATE TABLE tasks(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT,
+      plan_id INTEGER,
+      wave_id_fk INTEGER,
+      title TEXT,
+      status TEXT DEFAULT 'pending'
+    );
+  " >/dev/null
+
+  sqlite3 "$TEST_DB" "INSERT INTO plans(id,status) VALUES (1,'doing');"
+  sqlite3 "$TEST_DB" "INSERT INTO waves(id,plan_id,status) VALUES (1,1,'pending');"
+
+  for i in 1 2 3 4 5; do
+    sqlite3 "$TEST_DB" "
+      INSERT INTO peer_heartbeats(peer_name,status,last_seen,cpu_load,mem_used_gb,mem_total_gb,tasks_in_progress,cost_tier)
+      VALUES('peer$i','online',datetime('now'),$((i * 15)),4.0,16.0,$((i - 1)),'free');
+    "
+  done
+
+  export MESH_MAX_TASKS_PER_PEER=3
+  export DASHBOARD_DB="$TEST_DB"
+
+  mkdir -p "$TEST_TMP_DIR/bin"
+  cat >"$TEST_TMP_DIR/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+host=""
+skip=0
+for a in "$@"; do
+  if [[ "$skip" -eq 1 ]]; then skip=0; continue; fi
+  if [[ "$a" == "-o" ]]; then skip=1; continue; fi
+  [[ "$a" == -* ]] && continue
+  if [[ -z "$host" ]]; then host="$a"; continue; fi
+done
+
+cpu=$(sqlite3 "${TEST_DB}" "SELECT COALESCE(cpu_load,0) FROM peer_heartbeats WHERE peer_name='${host}';" 2>/dev/null || echo 0)
+tip=$(sqlite3 "${TEST_DB}" "SELECT COALESCE(tasks_in_progress,0) FROM peer_heartbeats WHERE peer_name='${host}';" 2>/dev/null || echo 0)
+
+printf '{"peer":"%s","cpu_load":%s,"tasks_in_progress":%s,"capabilities":"ollama","cost_tier":"free","privacy_safe":true,"online":true}\n' "$host" "${cpu:-0}" "${tip:-0}"
+SH
+  chmod +x "$TEST_TMP_DIR/bin/ssh"
+  export PATH="$TEST_TMP_DIR/bin:$PATH"
+}
+
+teardown() {
+  rm -f "${TEST_DB:-}" 2>/dev/null || true
+  rm -rf "${TEST_TMP_DIR:-}" 2>/dev/null || true
+}
+trap teardown EXIT
+
+peers_json_from_mock() {
+  local out="[" first=1 p row
+  for p in peer1 peer2 peer3 peer4 peer5; do
+    row="$(ssh "$p" "echo load" 2>/dev/null || true)"
+    [[ -z "$row" ]] && continue
+    if [[ "$first" -eq 0 ]]; then out+=$',\n'; fi
+    out+="$row"
+    first=0
+  done
+  out+=$'\n]'
+  echo "$out"
+}
+
+filter_available_peers() {
+  local peers_json="$1" line tip out="[" first=1
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" == "[" || "$line" == "]" || "$line" == "," ]] && continue
+    line="${line%,}"
+    tip="$(_json_field "$line" "tasks_in_progress")"
+    [[ "$tip" =~ ^[0-9]+$ ]] || tip=0
+    if [[ "$tip" -lt "$MESH_MAX_TASKS_PER_PEER" ]]; then
+      if [[ "$first" -eq 0 ]]; then out+=$',\n'; fi
+      out+="$line"
+      first=0
+    fi
+  done <<<"$peers_json"
+  out+=$'\n]'
+  echo "$out"
+}
+
+setup
+source "$SCORING_LIB"
+
+echo "=== test-mesh-concurrency.sh ==="
+
+# T1: Capacity check: full peer has low/non-positive score vs available peer
+FULL='{"peer":"full","online":true,"privacy_safe":true,"cpu_load":2.5,"tasks_in_progress":3,"capabilities":"ollama","cost_tier":"premium"}'
+OPEN='{"peer":"open","online":true,"privacy_safe":true,"cpu_load":2.5,"tasks_in_progress":2,"capabilities":"ollama","cost_tier":"premium"}'
+S_FULL="$(mesh_score_peer "$FULL" "" 0 2>/dev/null || echo -99)"
+S_OPEN="$(mesh_score_peer "$OPEN" "" 0 2>/dev/null || echo -99)"
+if [[ "$S_FULL" -le 0 && "$S_FULL" -lt "$S_OPEN" ]]; then
+  pass "T1: full peer score is low and lower than available peer"
+else
+  fail "T1: full peer should score low/lower" "full<=0 and full<open" "full=$S_FULL open=$S_OPEN"
+fi
+
+# T2: Rapid dispatch: 4 attempts to same best peer accepts only MESH_MAX_TASKS_PER_PEER
+accepted=0
+rejected=0
+for _ in 1 2 3 4; do
+  tip=$(sqlite3 "$TEST_DB" "SELECT tasks_in_progress FROM peer_heartbeats WHERE peer_name='peer1';")
+  peer_json="{\"peer\":\"peer1\",\"online\":true,\"privacy_safe\":true,\"cpu_load\":0.2,\"tasks_in_progress\":${tip},\"capabilities\":\"ollama\",\"cost_tier\":\"free\"}"
+  score="$(mesh_score_peer "$peer_json" "" 0 2>/dev/null || echo -99)"
+  if [[ "$tip" -lt "$MESH_MAX_TASKS_PER_PEER" && "$score" -ge 0 ]]; then
+    accepted=$((accepted + 1))
+    sqlite3 "$TEST_DB" "UPDATE peer_heartbeats SET tasks_in_progress=tasks_in_progress+1 WHERE peer_name='peer1';"
+  else
+    rejected=$((rejected + 1))
+  fi
+done
+if [[ "$accepted" -eq "$MESH_MAX_TASKS_PER_PEER" && "$rejected" -eq 1 ]]; then
+  pass "T2: rapid dispatch enforces per-peer capacity"
+else
+  fail "T2: capacity should cap accepted dispatches" "accepted=3 rejected=1" "accepted=$accepted rejected=$rejected"
+fi
+
+# T3: Overflow routing: when best peer is full, next task goes to next-best
+sqlite3 "$TEST_DB" "
+  UPDATE peer_heartbeats SET tasks_in_progress=2;
+  UPDATE peer_heartbeats SET cpu_load=15;
+  UPDATE peer_heartbeats SET tasks_in_progress=3, cpu_load=15 WHERE peer_name='peer1';
+  UPDATE peer_heartbeats SET tasks_in_progress=0, cpu_load=15 WHERE peer_name='peer2';
+"
+PEERS_JSON="$(peers_json_from_mock)"
+WINNER="$(mesh_best_peer "$PEERS_JSON" "" 0 2>/dev/null || true)"
+if [[ "$WINNER" == "peer2" ]]; then
+  pass "T3: overflow routes task to next-best peer"
+else
+  fail "T3: expected overflow routing to peer2" "peer2" "${WINNER:-<empty>}"
+fi
+
+# T4: WAL concurrency: 3 parallel writes do not hit SQLITE_BUSY
+for i in 1 2 3; do
+  (
+    sqlite3 "$TEST_DB" "
+      PRAGMA busy_timeout=5000;
+      BEGIN IMMEDIATE;
+      INSERT INTO tasks(task_id,plan_id,wave_id_fk,title,status)
+      VALUES('wal-$i',1,1,'wal-$i','pending');
+      SELECT randomblob(50000);
+      COMMIT;
+    "
+  ) >"$TEST_TMP_DIR/wal-$i.out" 2>"$TEST_TMP_DIR/wal-$i.err" &
+  eval "pid_$i=$!"
+done
+
+wal_ok=1
+for i in 1 2 3; do
+  eval "pid=\$pid_$i"
+  if ! wait "$pid"; then wal_ok=0; fi
+  if grep -Eqi 'SQLITE_BUSY|database is locked|busy' "$TEST_TMP_DIR/wal-$i.err"; then wal_ok=0; fi
+done
+
+if [[ "$wal_ok" -eq 1 ]]; then
+  pass "T4: WAL mode handled 3 parallel writes without SQLITE_BUSY"
+else
+  fail "T4: WAL concurrent writes should avoid SQLITE_BUSY"
+fi
+
+# T5: Full capacity: all peers maxed -> no capacity-qualified peer, mesh_best_peer returns empty
+sqlite3 "$TEST_DB" "UPDATE peer_heartbeats SET tasks_in_progress=$MESH_MAX_TASKS_PER_PEER;"
+ALL_PEERS="$(peers_json_from_mock)"
+AVAILABLE="$(filter_available_peers "$ALL_PEERS")"
+FULL_WINNER="$(mesh_best_peer "$AVAILABLE" "" 0 2>/dev/null || true)"
+if [[ -z "$FULL_WINNER" ]]; then
+  pass "T5: full-capacity peer set yields empty mesh_best_peer result"
+else
+  fail "T5: expected empty winner when all peers are at max" "<empty>" "$FULL_WINNER"
+fi
+
+assert_line_count "$0" 250 "test-mesh-concurrency.sh <= 250 lines"
+exit_with_summary "mesh-concurrency"

--- a/tests/test-mesh-edge-cases.sh
+++ b/tests/test-mesh-edge-cases.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+auto_cleanup_temp_dir
+
+DISPATCHER="$REPO_ROOT/scripts/mesh-dispatcher.sh"
+PREFLIGHT="$REPO_ROOT/scripts/mesh-preflight.sh"
+MIGRATE="$REPO_ROOT/scripts/mesh-migrate.sh"
+SCORING="$REPO_ROOT/scripts/lib/mesh-scoring.sh"
+PEERS_LIB="$REPO_ROOT/scripts/lib/peers.sh"
+
+echo "=== test-mesh-edge-cases.sh ==="
+
+mkbin() { mkdir -p "$TEST_TEMP_DIR/bin"; }
+
+# T1: Peer offline mid-dispatch -> warning + retry next-best (simulated harness)
+{
+  mkbin
+  LOG="$TEST_TEMP_DIR/t1.log"; : >"$LOG"
+  cat >"$TEST_TEMP_DIR/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+state_file="${STATE_FILE:?}"
+peer="${1:-}"
+count=0; [[ -f "$state_file" ]] && count=$(cat "$state_file")
+count=$((count+1)); echo "$count" > "$state_file"
+if [[ "$count" -eq 1 ]]; then exit 0; fi
+[[ "$peer" == "peer-a" ]] && exit 1
+exit 0
+SH
+  chmod +x "$TEST_TEMP_DIR/bin/ssh"
+  export PATH="$TEST_TEMP_DIR/bin:$PATH" STATE_FILE="$TEST_TEMP_DIR/t1.count"
+
+  dispatch_with_retry() {
+    local peers=("peer-a" "peer-b") t
+    for t in 1 2; do
+      for p in "${peers[@]}"; do
+        if ssh "$p" "run" >/dev/null 2>&1; then
+          echo "task $t -> $p" >>"$LOG"; break
+        else
+          echo "WARN: $p offline mid-dispatch" >>"$LOG"
+        fi
+      done
+    done
+  }
+  dispatch_with_retry
+  if grep -q 'WARN: peer-a offline' "$LOG" && grep -q 'task 2 -> peer-b' "$LOG"; then
+    pass "T1: offline peer warning + next-best retry"
+  else
+    fail "T1: expected warning and fallback dispatch" "warn+peer-b" "$(cat "$LOG")"
+  fi
+}
+
+# T2: timeout kills hung ssh and moves to next peer (simulated harness)
+{
+  mkbin
+  cat >"$TEST_TEMP_DIR/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+peer="${1:-}"
+if [[ "$peer" == "peer-a" ]]; then sleep 5; exit 0; fi
+exit 0
+SH
+  chmod +x "$TEST_TEMP_DIR/bin/ssh"
+  export PATH="$TEST_TEMP_DIR/bin:$PATH"
+  winner=""
+  if timeout 2 ssh peer-a run >/dev/null 2>&1; then winner="peer-a"; fi
+  if [[ -z "$winner" ]]; then timeout 2 ssh peer-b run >/dev/null 2>&1 && winner="peer-b"; fi
+  [[ "$winner" == "peer-b" ]] && pass "T2: timeout fallback to next peer" || fail "T2: expected peer-b after timeout" "peer-b" "${winner:-<empty>}"
+}
+
+# Shared mock ssh for preflight tests; uses DF_KB to emulate disk-pressure policy
+mkbin
+cat >"$TEST_TEMP_DIR/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+skip=0; host_seen=0; cmd=""
+for a in "$@"; do
+  [[ "$skip" -eq 1 ]] && { skip=0; continue; }
+  [[ "$a" == "-o" ]] && { skip=1; continue; }
+  [[ "$a" == -* ]] && continue
+  [[ "$host_seen" -eq 0 ]] && { host_seen=1; continue; }
+  cmd+=" $a"
+done
+if [[ "$cmd" == *MISSING:* ]]; then
+  if [[ "${DF_KB:-9999999}" -lt 5242880 ]]; then
+    echo "MISSING: git"; echo "OPTIONAL:"
+  else
+    echo "MISSING:"; echo "OPTIONAL:"
+  fi
+else
+  echo "MISSING:"; echo "OPTIONAL:"
+fi
+SH
+chmod +x "$TEST_TEMP_DIR/bin/ssh"
+
+# T3: mesh-preflight.sh with <5GB equivalent mock pressure -> non-zero
+{
+  export PATH="$TEST_TEMP_DIR/bin:$PATH" DF_KB=1000
+  rc=0; bash "$PREFLIGHT" test-peer >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -ne 0 ]] && pass "T3: preflight fails under low-space mock" || fail "T3: expected non-zero for low space mock"
+}
+
+# T4: mesh-preflight.sh with >=5GB equivalent mock pressure -> zero
+{
+  export PATH="$TEST_TEMP_DIR/bin:$PATH" DF_KB=9000000
+  if bash "$PREFLIGHT" test-peer >/dev/null 2>&1; then
+    pass "T4: preflight passes with sufficient space mock"
+  else
+    fail "T4: expected exit 0 for sufficient space mock"
+  fi
+}
+
+# T5: mesh-migrate.sh unreachable during DB copy triggers rollback; source unchanged
+{
+  mkbin
+  CLAUDE_HOME="$TEST_TEMP_DIR/claude"; export CLAUDE_HOME
+  mkdir -p "$CLAUDE_HOME/data" "$CLAUDE_HOME/scripts"
+  SRC_DB="$CLAUDE_HOME/data/dashboard.db"
+  TGT_DB="$TEST_TEMP_DIR/target.db"
+  sqlite3 "$SRC_DB" "CREATE TABLE plans(id INTEGER PRIMARY KEY,status TEXT,execution_host TEXT,worktree_path TEXT); CREATE TABLE waves(id INTEGER PRIMARY KEY,plan_id INTEGER,worktree_path TEXT); CREATE TABLE tasks(id INTEGER PRIMARY KEY,plan_id INTEGER,wave_id_fk INTEGER,status TEXT,executor_host TEXT); CREATE TABLE peer_heartbeats(host TEXT,role TEXT); INSERT INTO plans VALUES(1,'doing','source-host','~/repo'); INSERT INTO waves VALUES(1,1,'~/repo');"
+  sqlite3 "$TGT_DB" "CREATE TABLE plans(id INTEGER PRIMARY KEY,status TEXT,execution_host TEXT,worktree_path TEXT); CREATE TABLE waves(id INTEGER PRIMARY KEY,plan_id INTEGER,worktree_path TEXT); CREATE TABLE tasks(id INTEGER PRIMARY KEY,plan_id INTEGER,wave_id_fk INTEGER,status TEXT,executor_host TEXT); INSERT INTO plans VALUES(1,'doing','target-old','~/repo');"
+  cp "$TGT_DB" "$TGT_DB.bak"
+  cat >"$CLAUDE_HOME/scripts/mesh-heartbeat.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$CLAUDE_HOME/scripts/mesh-heartbeat.sh"
+
+  cat >"$TEST_TEMP_DIR/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+skip=0; host_seen=0; cmd_args=()
+for a in "$@"; do
+  [[ "$skip" -eq 1 ]] && { skip=0; continue; }
+  [[ "$a" == "-o" ]] && { skip=1; continue; }
+  [[ "$a" == -* ]] && continue
+  [[ "$host_seen" -eq 0 ]] && { host_seen=1; continue; }
+  cmd_args+=("$a")
+done
+cmd="${cmd_args[*]:-true}"
+cmd="${cmd//~\/.claude\/data\/dashboard.db/$MOCK_TARGET_DB}"
+cmd="${cmd//~\/.claude\/data\/dashboard.db.bak/$MOCK_TARGET_DB.bak}"
+[[ "$cmd" == 'echo $HOME' ]] && { echo "/home/mock"; exit 0; }
+[[ "$cmd" == 'hostname -s' ]] && { echo "mock-host"; exit 0; }
+[[ "$cmd" == 'true' ]] && exit 0
+bash -lc "$cmd" >/dev/null 2>&1 || true
+exit 0
+SH
+  cat >"$TEST_TEMP_DIR/bin/scp" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+# Fail DB copy to trigger rollback path
+for a in "$@"; do [[ "$a" == *"dashboard.db"* ]] && exit 1; done
+exit 0
+SH
+  chmod +x "$TEST_TEMP_DIR/bin/ssh" "$TEST_TEMP_DIR/bin/scp"
+  export PATH="$TEST_TEMP_DIR/bin:$PATH" MOCK_TARGET_DB="$TGT_DB"
+
+  rc=0; bash "$MIGRATE" 1 mock-peer --no-launch >/dev/null 2>&1 || rc=$?
+  src_host=$(sqlite3 "$SRC_DB" "SELECT execution_host FROM plans WHERE id=1;")
+  if [[ "$rc" -ne 0 && "$src_host" == "source-host" ]]; then
+    pass "T5: migrate rollback path leaves source unchanged"
+  else
+    fail "T5: expected rollback failure with unchanged source" "rc!=0 and source-host" "rc=$rc host=$src_host"
+  fi
+}
+
+# T6: empty peers.conf -> dispatcher exits cleanly with no-peer output
+{
+  EMPTY_CONF="$TEST_TEMP_DIR/empty-peers.conf"; : >"$EMPTY_CONF"
+  DB="$TEST_TEMP_DIR/t6.db"
+  sqlite3 "$DB" "CREATE TABLE tasks(id INTEGER PRIMARY KEY,plan_id INTEGER,title TEXT,privacy_required INTEGER,status TEXT,executor_host TEXT); CREATE TABLE plans(id INTEGER PRIMARY KEY,status TEXT); INSERT INTO plans VALUES(1,'doing'); INSERT INTO tasks VALUES(1,1,'edge task',0,'pending','');"
+  out=$(PEERS_CONF="$EMPTY_CONF" DB_PATH="$DB" bash "$DISPATCHER" --plan 1 2>&1 || true)
+  if echo "$out" | grep -qi 'no peer\|skipped'; then
+    pass "T6: dispatcher handles empty peers config cleanly"
+  else
+    fail "T6: expected clean no-peer behavior" "contains no peer/skipped" "$out"
+  fi
+}
+
+# T7: malformed peer JSON (missing fields) -> mesh_score_peer negative/no crash
+{
+  source "$SCORING"
+  bad='{"peer":"broken"}'
+  score=$(mesh_score_peer "$bad" "" 1 2>/dev/null || echo "-99")
+  [[ "$score" =~ ^- ]] && pass "T7: malformed peer JSON safely disqualified" || fail "T7: malformed JSON should disqualify" "negative" "$score"
+}
+
+# T8: duplicate peer names in peers.conf -> peers_load no crash
+{
+  DCONF="$TEST_TEMP_DIR/dup-peers.conf"
+  cat >"$DCONF" <<'CONF'
+[dup]
+ssh_alias=host-a
+status=active
+[dup]
+ssh_alias=host-b
+status=active
+CONF
+  out=$(PEERS_CONF="$DCONF" bash -c "source '$PEERS_LIB'; peers_load; peers_list" 2>&1 || true)
+  if [[ -n "$out" ]]; then
+    pass "T8: peers_load handles duplicate names without crashing"
+  else
+    fail "T8: expected non-empty peers_list with duplicate sections"
+  fi
+}
+
+assert_line_count "$0" 250 "test-mesh-edge-cases.sh <= 250 lines"
+exit_with_summary "mesh-edge-cases"

--- a/tests/test-mesh-failover.sh
+++ b/tests/test-mesh-failover.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+auto_cleanup_temp_dir
+
+echo "=== test-mesh-failover.sh ==="
+
+TEST_DB="$TEST_TEMP_DIR/mesh-failover.db"
+COORD_LIB="$TEST_TEMP_DIR/mesh-coordinator.lib.sh"
+COUNTER_FILE="/tmp/mesh-offline-peer-offline.count"
+
+# Load mesh-coordinator functions without executing CLI main case.
+# Keep SCRIPT_DIR-relative library sources valid in extracted file.
+mkdir -p "$TEST_TEMP_DIR/lib"
+ln -sf "$REPO_ROOT/scripts/lib/peers.sh" "$TEST_TEMP_DIR/lib/peers.sh"
+ln -sf "$REPO_ROOT/scripts/lib/notify-config.sh" "$TEST_TEMP_DIR/lib/notify-config.sh"
+awk '/^# Main/{exit} {print}' "$REPO_ROOT/scripts/mesh-coordinator.sh" >"$COORD_LIB"
+source "$COORD_LIB"
+
+# Test overrides/mocks
+DB="$TEST_DB"
+_log() { :; }
+_info() { :; }
+_ok() { :; }
+_warn() { :; }
+_err() { :; }
+_notify() { :; }
+peers_self() { echo "self-peer"; }
+_db() { sqlite3 "$DB" "$@"; }
+
+now_epoch() { date +%s; }
+
+init_db() {
+  rm -f "$DB"
+  sqlite3 "$DB" <<'SQL'
+CREATE TABLE peer_heartbeats (
+  peer_name TEXT PRIMARY KEY,
+  last_seen INTEGER NOT NULL
+);
+CREATE TABLE mesh_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_type TEXT,
+  source_peer TEXT,
+  status TEXT DEFAULT 'pending',
+  payload TEXT,
+  created_at INTEGER
+);
+CREATE TABLE plans (
+  id INTEGER PRIMARY KEY,
+  status TEXT,
+  execution_host TEXT
+);
+CREATE TABLE tasks (
+  id INTEGER PRIMARY KEY,
+  status TEXT,
+  executor_host TEXT,
+  assigned_at INTEGER
+);
+CREATE TABLE coordinator_claim (
+  id INTEGER PRIMARY KEY CHECK (id=1),
+  owner TEXT,
+  last_seen INTEGER
+);
+INSERT INTO coordinator_claim (id, owner, last_seen) VALUES (1, NULL, 0);
+SQL
+}
+
+claim_coordinator() {
+  local peer="$1"
+  local now cutoff changed
+  now=$(now_epoch)
+  cutoff=$((now - 300)) # 5 min stale window
+  changed=$(sqlite3 "$DB" <<SQL
+BEGIN IMMEDIATE;
+UPDATE coordinator_claim
+SET owner='${peer}', last_seen=${now}
+WHERE id=1 AND (owner IS NULL OR owner='${peer}' OR last_seen <= ${cutoff});
+SELECT changes();
+COMMIT;
+SQL
+)
+  [[ "${changed##*$'\n'}" -eq 1 ]]
+}
+
+# Fixed-loop mock based on mesh-coordinator _check_offline_nodes logic.
+_check_offline_nodes() {
+  local now peer_name last_seen age active count max_count
+  now=$(now_epoch)
+  max_count=$((REASSIGN_GRACE + 1))
+  while IFS='|' read -r peer_name last_seen; do
+    [[ -z "$peer_name" ]] && continue
+    age=$((now - last_seen))
+    [[ $age -lt $OFFLINE_THRESHOLD ]] && continue
+    active=$(_db "SELECT id FROM plans WHERE status='doing' AND execution_host='${peer_name}' LIMIT 1;")
+    [[ -z "$active" ]] && continue
+    count=0
+    [[ -f "$COUNTER_FILE" ]] && count=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+    if [[ $count -lt $max_count ]]; then
+      count=$((count + 1))
+      echo "$count" >"$COUNTER_FILE"
+    fi
+  done < <(_db "SELECT peer_name,last_seen FROM peer_heartbeats WHERE peer_name!='$(peers_self)';")
+}
+
+check_reassign_threshold() {
+  local now cutoff_offline cutoff_reassign
+  now=$(now_epoch)
+  cutoff_offline=$((now - OFFLINE_THRESHOLD))
+  cutoff_reassign=$((now - REASSIGN_THRESHOLD))
+  _db "INSERT INTO mesh_events (event_type, source_peer, status, payload, created_at)
+       SELECT 'reassign_needed', t.executor_host, 'pending', '{\"reason\":\"offline_threshold\"}', ${now}
+       FROM tasks t
+       JOIN peer_heartbeats p ON p.peer_name=t.executor_host
+       WHERE t.status='in_progress'
+         AND t.assigned_at <= ${cutoff_reassign}
+         AND p.last_seen <= ${cutoff_offline};"
+}
+
+# T1: stale coordinator can be claimed by new peer.
+init_db
+sqlite3 "$DB" "UPDATE coordinator_claim SET owner='old-coord', last_seen=$(($(now_epoch)-360)) WHERE id=1;"
+if claim_coordinator "new-peer"; then
+  owner=$(sqlite3 "$DB" "SELECT owner FROM coordinator_claim WHERE id=1;")
+  [[ "$owner" == "new-peer" ]] && pass "T1: stale coordinator detection" || fail "T1: owner mismatch" "new-peer" "$owner"
+else
+  fail "T1: expected claim to succeed"
+fi
+
+# T2: atomicity - two rapid claims in one transaction, exactly one wins.
+init_db
+out=$(sqlite3 "$DB" <<SQL
+BEGIN IMMEDIATE;
+UPDATE coordinator_claim
+SET owner='peer-a', last_seen=$(now_epoch)
+WHERE id=1 AND (owner IS NULL OR last_seen <= $(($(now_epoch)-300)));
+SELECT changes();
+UPDATE coordinator_claim
+SET owner='peer-b', last_seen=$(now_epoch)
+WHERE id=1 AND (owner IS NULL OR last_seen <= $(($(now_epoch)-300)));
+SELECT changes();
+COMMIT;
+SQL
+)
+c1=$(echo "$out" | sed -n '1p')
+c2=$(echo "$out" | sed -n '2p')
+won=$((c1 + c2))
+[[ "$won" -eq 1 ]] && pass "T2: claim atomicity" || fail "T2: expected exactly one claim" "1" "$won"
+
+# T3: fresh coordinator heartbeat prevents reclaim.
+init_db
+sqlite3 "$DB" "UPDATE coordinator_claim SET owner='incumbent', last_seen=$(($(now_epoch)-30)) WHERE id=1;"
+if claim_coordinator "challenger"; then
+  fail "T3: active coordinator should be retained"
+else
+  owner=$(sqlite3 "$DB" "SELECT owner FROM coordinator_claim WHERE id=1;")
+  [[ "$owner" == "incumbent" ]] && pass "T3: active coordinator retention" || fail "T3: owner changed unexpectedly" "incumbent" "$owner"
+fi
+
+# T4: grace counter caps at REASSIGN_GRACE + 1.
+init_db
+rm -f "$COUNTER_FILE"
+REASSIGN_GRACE=2
+OFFLINE_THRESHOLD=60
+sqlite3 "$DB" "INSERT INTO peer_heartbeats VALUES ('peer-offline', $(($(now_epoch)-1000)));"
+sqlite3 "$DB" "INSERT INTO plans VALUES (1,'doing','peer-offline');"
+for _ in {1..10}; do _check_offline_nodes; done
+count=$(cat "$COUNTER_FILE")
+expected=$((REASSIGN_GRACE + 1))
+[[ "$count" -eq "$expected" ]] && pass "T4: grace counter cap" || fail "T4: counter exceeded cap" "$expected" "$count"
+rm -f "$COUNTER_FILE"
+
+# T5: recovered peer does not reclaim coordinator from healthy incumbent.
+init_db
+sqlite3 "$DB" "UPDATE coordinator_claim SET owner='healthy-incumbent', last_seen=$(($(now_epoch)-20)) WHERE id=1;"
+sqlite3 "$DB" "INSERT INTO peer_heartbeats VALUES ('peer-recovered', $(($(now_epoch)-2000)));"
+sqlite3 "$DB" "UPDATE peer_heartbeats SET last_seen=$(now_epoch) WHERE peer_name='peer-recovered';"
+if claim_coordinator "peer-recovered"; then
+  fail "T5: recovered peer should not reclaim"
+else
+  owner=$(sqlite3 "$DB" "SELECT owner FROM coordinator_claim WHERE id=1;")
+  [[ "$owner" == "healthy-incumbent" ]] && pass "T5: offline peer recovery" || fail "T5: incumbent replaced unexpectedly" "healthy-incumbent" "$owner"
+fi
+
+# T6: in-progress task on offline peer beyond threshold triggers reassign event.
+init_db
+OFFLINE_THRESHOLD=900
+REASSIGN_THRESHOLD=1800
+sqlite3 "$DB" "INSERT INTO peer_heartbeats VALUES ('peer-z', $(($(now_epoch)-4000)));"
+sqlite3 "$DB" "INSERT INTO tasks VALUES (1,'in_progress','peer-z', $(($(now_epoch)-1900)));"
+check_reassign_threshold
+reassign_events=$(sqlite3 "$DB" "SELECT COUNT(*) FROM mesh_events WHERE event_type='reassign_needed' AND source_peer='peer-z';")
+[[ "$reassign_events" -eq 1 ]] && pass "T6: reassign threshold" || fail "T6: expected reassign event" "1" "$reassign_events"
+
+exit_with_summary "mesh-failover"

--- a/tests/test-mesh-live-ssh.sh
+++ b/tests/test-mesh-live-ssh.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# test-mesh-live-ssh.sh — Real SSH integration tests against active mesh peers
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+source "$REPO_ROOT/scripts/lib/peers.sh"
+
+SSH_OPTS=(-o ConnectTimeout=5 -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+SCP_OPTS=(-o ConnectTimeout=5 -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+
+echo "=== mesh live SSH tests ==="
+
+timeout_run() {
+  local secs="$1"
+  shift
+  "$@" &
+  local pid=$!
+  local ticks=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if (( ticks >= secs * 10 )); then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+  wait "$pid"
+}
+
+is_network_error() {
+  local out="$1"
+  [[ "$out" =~ [Tt]imed[[:space:]]out ]] ||
+    [[ "$out" =~ [Nn]o[[:space:]]route[[:space:]]to[[:space:]]host ]] ||
+    [[ "$out" =~ [Nn]etwork[[:space:]]is[[:space:]]unreachable ]] ||
+    [[ "$out" =~ [Cc]ould[[:space:]]not[[:space:]]resolve[[:space:]]hostname ]] ||
+    [[ "$out" =~ [Nn]ame[[:space:]]or[[:space:]]service[[:space:]]not[[:space:]]known ]] ||
+    [[ "$out" =~ [Cc]onnection[[:space:]]refused ]] ||
+    [[ "$out" =~ [Cc]onnection[[:space:]]closed ]] ||
+    [[ "$out" =~ [Kk]ex_exchange_identification ]]
+}
+
+peer_dest() {
+  local peer="$1" target user
+  target="$(peers_best_route "$peer")"
+  user="$(peers_get "$peer" user 2>/dev/null || echo "")"
+  [[ -n "$user" ]] && echo "${user}@${target}" || echo "$target"
+}
+
+ssh_peer() {
+  local peer="$1"
+  shift
+  ssh "${SSH_OPTS[@]}" "$(peer_dest "$peer")" "$@"
+}
+
+scp_to_peer() {
+  local peer="$1" src="$2" dst="$3"
+  scp "${SCP_OPTS[@]}" "$src" "$(peer_dest "$peer"):$dst"
+}
+
+scp_from_peer() {
+  local peer="$1" src="$2" dst="$3"
+  scp "${SCP_OPTS[@]}" "$(peer_dest "$peer"):$src" "$dst"
+}
+
+run_capture() {
+  local __out_var="$1"
+  shift
+  local tmp rc
+  tmp="$(mktemp)"
+  if timeout_run 10 "$@" >"$tmp" 2>&1; then
+    printf -v "$__out_var" '%s' "$(cat "$tmp")"
+    rm -f "$tmp"
+    return 0
+  fi
+  rc=$?
+  printf -v "$__out_var" '%s' "$(cat "$tmp")"
+  rm -f "$tmp"
+  return "$rc"
+}
+
+skip_or_fail() {
+  local title="$1" rc="$2" out="$3"
+  if [[ "$rc" -eq 124 ]] || is_network_error "$out"; then
+    pass "$title (SKIP: ${out:-timeout})"
+    return 0
+  fi
+  fail "$title" "command succeeded" "rc=$rc output=${out:-<empty>}"
+  return 1
+}
+
+if [[ "${MESH_TEST_LIVE:-0}" != "1" ]]; then
+  pass "MESH_TEST_LIVE!=1; skipping all live SSH tests"
+  print_test_summary "mesh live SSH"
+  exit 0
+fi
+
+peers_load
+ACTIVE_PEERS=()
+while IFS= read -r peer; do
+  ACTIVE_PEERS+=("$peer")
+done < <(peers_list)
+if [[ "${#ACTIVE_PEERS[@]}" -eq 0 ]]; then
+  pass "No active peers found; skipping live SSH tests"
+  print_test_summary "mesh live SSH"
+  exit 0
+fi
+
+# T1: SSH connectivity to each active peer
+for peer in "${ACTIVE_PEERS[@]}"; do
+  out=""
+  if run_capture out ssh_peer "$peer" echo ok; then
+    [[ "$out" == "ok" ]] && pass "T1 ssh connectivity [$peer]" || fail "T1 ssh connectivity [$peer]" "ok" "$out"
+  else
+    rc=$?
+    skip_or_fail "T1 ssh connectivity [$peer]" "$rc" "$out"
+  fi
+done
+
+# T2: Remote load query parses cleanly
+for peer in "${ACTIVE_PEERS[@]}"; do
+  out=""
+  if run_capture out ssh_peer "$peer" uptime; then
+    parsed="$(echo "$out" | sed -nE 's/.*load averages?: *([0-9]+[.,][0-9]+).*/\1/p' | head -n1 | tr ',' '.')"
+    [[ -n "$parsed" ]] && pass "T2 uptime parse [$peer]" || fail "T2 uptime parse [$peer]" "load value" "$out"
+  else
+    rc=$?
+    skip_or_fail "T2 uptime parse [$peer]" "$rc" "$out"
+  fi
+done
+
+# T3: Remote Claude CLI exists/version
+for peer in "${ACTIVE_PEERS[@]}"; do
+  out=""
+  if run_capture out ssh_peer "$peer" "claude --version || which claude"; then
+    [[ -n "$out" ]] && pass "T3 claude cli [$peer]" || fail "T3 claude cli [$peer]" "non-empty output" "<empty>"
+  else
+    rc=$?
+    skip_or_fail "T3 claude cli [$peer]" "$rc" "$out"
+  fi
+done
+
+# T4: Remote DB file exists
+for peer in "${ACTIVE_PEERS[@]}"; do
+  out=""
+  if run_capture out ssh_peer "$peer" test -f ~/.claude/data/dashboard.db; then
+    pass "T4 remote DB exists [$peer]"
+  else
+    rc=$?
+    skip_or_fail "T4 remote DB exists [$peer]" "$rc" "$out"
+  fi
+done
+
+# T5: Bidirectional ping A<->B
+if [[ "${#ACTIVE_PEERS[@]}" -lt 2 ]]; then
+  pass "T5 bidirectional ping (SKIP: need at least 2 active peers)"
+else
+  a="${ACTIVE_PEERS[0]}"
+  b="${ACTIVE_PEERS[1]}"
+  aip="$(peers_get "$a" tailscale_ip 2>/dev/null || echo "")"
+  bip="$(peers_get "$b" tailscale_ip 2>/dev/null || echo "")"
+  if [[ -z "$aip" || -z "$bip" ]]; then
+    pass "T5 bidirectional ping (SKIP: missing tailscale_ip for $a or $b)"
+  else
+    out_ab=""
+    out_ba=""
+    rc_ab=0
+    rc_ba=0
+    run_capture out_ab ssh_peer "$a" "ping -c 1 -W 2 $bip >/dev/null 2>&1 || ping -c 1 -t 2 $bip >/dev/null 2>&1" || rc_ab=$?
+    run_capture out_ba ssh_peer "$b" "ping -c 1 -W 2 $aip >/dev/null 2>&1 || ping -c 1 -t 2 $aip >/dev/null 2>&1" || rc_ba=$?
+    if [[ "$rc_ab" -eq 0 && "$rc_ba" -eq 0 ]]; then
+      pass "T5 bidirectional ping [$a<->$b]"
+    elif [[ "$rc_ab" -eq 124 || "$rc_ba" -eq 124 ]] || is_network_error "$out_ab $out_ba"; then
+      pass "T5 bidirectional ping [$a<->$b] (SKIP: network issue)"
+    else
+      fail "T5 bidirectional ping [$a<->$b]" "both directions succeed" "A->B rc=$rc_ab B->A rc=$rc_ba"
+    fi
+  fi
+fi
+
+# T6: mesh-load-query JSON for first active peer
+first_peer="${ACTIVE_PEERS[0]}"
+out=""
+if run_capture out bash "$REPO_ROOT/scripts/mesh-load-query.sh" --json --peer "$first_peer"; then
+  if echo "$out" | python3 -c 'import json,sys; json.load(sys.stdin); print("ok")' >/dev/null 2>&1; then
+    pass "T6 mesh-load-query JSON [$first_peer]"
+  else
+    fail "T6 mesh-load-query JSON [$first_peer]" "valid JSON" "$out"
+  fi
+else
+  rc=$?
+  skip_or_fail "T6 mesh-load-query JSON [$first_peer]" "$rc" "$out"
+fi
+
+# T7: mesh-db-sync-tasks dry-run per peer
+for peer in "${ACTIVE_PEERS[@]}"; do
+  out=""
+  if run_capture out bash "$REPO_ROOT/scripts/mesh-db-sync-tasks.sh" --peer "$peer" --dry-run; then
+    pass "T7 db-sync dry-run [$peer]"
+  else
+    rc=$?
+    skip_or_fail "T7 db-sync dry-run [$peer]" "$rc" "$out"
+  fi
+done
+
+# T8: SCP round-trip compare
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+for peer in "${ACTIVE_PEERS[@]}"; do
+  local_src="$TMP_DIR/src-${peer}.txt"
+  local_back="$TMP_DIR/back-${peer}.txt"
+  remote_file="~/.claude-live-ssh-${RANDOM}.txt"
+  echo "mesh-live-ssh-$peer-$(date +%s)" >"$local_src"
+
+  out_to=""
+  out_from=""
+  rc_to=0
+  rc_from=0
+  run_capture out_to scp_to_peer "$peer" "$local_src" "$remote_file" || rc_to=$?
+  run_capture out_from scp_from_peer "$peer" "$remote_file" "$local_back" || rc_from=$?
+  timeout_run 10 ssh_peer "$peer" "rm -f $remote_file" >/dev/null 2>&1 || true
+
+  if [[ "$rc_to" -eq 0 && "$rc_from" -eq 0 ]]; then
+    if cmp -s "$local_src" "$local_back"; then
+      pass "T8 scp round-trip [$peer]"
+    else
+      fail "T8 scp round-trip [$peer]" "files match" "mismatch after round-trip"
+    fi
+  elif [[ "$rc_to" -eq 124 || "$rc_from" -eq 124 ]] || is_network_error "$out_to $out_from"; then
+    pass "T8 scp round-trip [$peer] (SKIP: network issue)"
+  else
+    fail "T8 scp round-trip [$peer]" "scp upload/download succeed" "upload rc=$rc_to download rc=$rc_from"
+  fi
+done
+
+print_test_summary "mesh live SSH"

--- a/tests/test-mesh-node-identity.sh
+++ b/tests/test-mesh-node-identity.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+auto_cleanup_temp_dir
+
+CORE_LIB="$REPO_ROOT/scripts/lib/plan-db-core.sh"
+PEERS_LIB="$REPO_ROOT/scripts/lib/peers.sh"
+NORMALIZE_SCRIPT="$REPO_ROOT/scripts/mesh-normalize-hosts.sh"
+
+plan_db_host() {
+	local peers_conf="${1:-}"
+	if [[ -n "$peers_conf" ]]; then
+		PEERS_CONF="$peers_conf" bash -c "set -euo pipefail; source '$CORE_LIB'; printf '%s' \"\$PLAN_DB_HOST\""
+	else
+		bash -c "set -euo pipefail; source '$CORE_LIB'; printf '%s' \"\$PLAN_DB_HOST\""
+	fi
+}
+
+echo "=== mesh node identity tests ==="
+
+# T1: PLAN_DB_HOST should not be legacy hostname variants.
+HOST_VALUE="$(plan_db_host)"
+if [[ -n "$HOST_VALUE" && ! "$HOST_VALUE" =~ ^(Mac|Mac\.lan|RobertoM3Max957|RobertoM3Max957\.lan)$ ]]; then
+	pass "T1: PLAN_DB_HOST is canonical (got '$HOST_VALUE')"
+else
+	fail "T1: PLAN_DB_HOST should not be legacy hostname variant" \
+		"not Mac/Mac.lan/RobertoM3Max957(.lan)" "${HOST_VALUE:-<empty>}"
+fi
+
+# T2: PLAN_DB_HOST should match peers_self (section name from peers.conf).
+SELF_PEER="$(bash -c "set -euo pipefail; source '$PEERS_LIB'; peers_load >/dev/null 2>&1 || true; peers_self")"
+if [[ -n "$SELF_PEER" && "$HOST_VALUE" == "$SELF_PEER" ]]; then
+	pass "T2: PLAN_DB_HOST matches peers_self ('$SELF_PEER')"
+else
+	fail "T2: PLAN_DB_HOST should match peers_self" \
+		"non-empty peers_self and equal values" \
+		"PLAN_DB_HOST='${HOST_VALUE:-<empty>}' peers_self='${SELF_PEER:-<empty>}'"
+fi
+
+# T3: Fallback without peers.conf should use hostname -s.
+TEMP_EMPTY="$TEST_TEMP_DIR/peers-empty.conf"
+: >"$TEMP_EMPTY"
+FALLBACK_HOST="$(
+	PEERS_CONF="$TEMP_EMPTY" bash -c "
+		set -euo pipefail
+		peers_self() { return 1; }
+		source '$CORE_LIB'
+		printf '%s' \"\$PLAN_DB_HOST\"
+	"
+)"
+EXPECTED_SHORT="$(hostname -s 2>/dev/null || hostname)"
+if [[ "$FALLBACK_HOST" == "$EXPECTED_SHORT" ]]; then
+	pass "T3: fallback host uses hostname -s ('$FALLBACK_HOST')"
+else
+	fail "T3: fallback should use hostname -s" "$EXPECTED_SHORT" "${FALLBACK_HOST:-<empty>}"
+fi
+
+# Shared fixtures for normalization tests (T4-T5).
+MOCK_BIN="$TEST_TEMP_DIR/mock-bin"
+mkdir -p "$MOCK_BIN"
+cat >"$MOCK_BIN/hostname" <<'EOM'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-s" ]]; then
+	echo "Mac"
+else
+	echo "Mac.lan"
+fi
+EOM
+cat >"$MOCK_BIN/scutil" <<'EOM'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--get" && "${2:-}" == "LocalHostName" ]]; then
+	echo "RobertoM3Max957"
+elif [[ "${1:-}" == "--get" && "${2:-}" == "ComputerName" ]]; then
+	echo "Roberto M3 Max 957"
+fi
+EOM
+chmod +x "$MOCK_BIN/hostname" "$MOCK_BIN/scutil"
+
+PEERS_FIXTURE="$TEST_TEMP_DIR/peers.conf"
+cat >"$PEERS_FIXTURE" <<'EOF_CONF'
+[m3max]
+ssh_alias=Mac
+dns_name=RobertoM3Max957.lan
+status=active
+tailscale_ip=100.64.0.10
+EOF_CONF
+
+DB_FILE="$TEST_TEMP_DIR/mesh-normalize.db"
+sqlite3 "$DB_FILE" <<'SQL'
+CREATE TABLE plans (id INTEGER PRIMARY KEY, execution_host TEXT);
+CREATE TABLE tasks (id INTEGER PRIMARY KEY, executor_host TEXT);
+CREATE TABLE peer_heartbeats (peer_name TEXT);
+INSERT INTO plans(id, execution_host) VALUES
+  (1, 'Mac.lan'),
+  (2, 'Mac'),
+  (3, 'RobertoM3Max957.lan');
+INSERT INTO tasks(id, executor_host) VALUES
+  (1, 'Mac.lan'),
+  (2, 'Mac'),
+  (3, 'RobertoM3Max957.lan');
+INSERT INTO peer_heartbeats(peer_name) VALUES ('test-junk');
+SQL
+
+# T4: dry-run should emit normalization UPDATE SQL.
+DRY_OUT="$TEST_TEMP_DIR/dry-run.sql"
+PATH="$MOCK_BIN:$PATH" PEERS_CONF="$PEERS_FIXTURE" CLAUDE_DB="$DB_FILE" DASHBOARD_DB="$DB_FILE" \
+	bash "$NORMALIZE_SCRIPT" --dry-run >"$DRY_OUT"
+if grep -q "UPDATE plans" "$DRY_OUT" && grep -q "UPDATE tasks" "$DRY_OUT" && grep -q "Mac.lan" "$DRY_OUT"; then
+	pass "T4: dry-run emits UPDATE statements and host variants"
+else
+	fail "T4: dry-run should emit UPDATE statements" \
+		"UPDATE plans + UPDATE tasks + Mac.lan" "$(cat "$DRY_OUT")"
+fi
+
+# T5: execution should normalize all hosts to canonical peer name.
+PATH="$MOCK_BIN:$PATH" PEERS_CONF="$PEERS_FIXTURE" CLAUDE_DB="$DB_FILE" DASHBOARD_DB="$DB_FILE" \
+	bash "$NORMALIZE_SCRIPT" >/dev/null
+BAD_PLANS="$(sqlite3 "$DB_FILE" "SELECT COUNT(*) FROM plans WHERE execution_host <> 'm3max';")"
+BAD_TASKS="$(sqlite3 "$DB_FILE" "SELECT COUNT(*) FROM tasks WHERE executor_host <> 'm3max';")"
+if [[ "$BAD_PLANS" == "0" && "$BAD_TASKS" == "0" ]]; then
+	pass "T5: normalize execution rewrites all hosts to m3max"
+else
+	fail "T5: normalize execution should canonicalize all hosts" "0 mismatches" \
+		"plans=$BAD_PLANS tasks=$BAD_TASKS"
+fi
+
+# T6: Python API host matching for variants -> m3max.
+PY_HOME="$TEST_TEMP_DIR/pyhome"
+mkdir -p "$PY_HOME/.claude/config"
+cp "$PEERS_FIXTURE" "$PY_HOME/.claude/config/peers.conf"
+
+if HOME="$PY_HOME" PYTHONPATH="$REPO_ROOT" python3 - <<'PY'
+from scripts.dashboard_web.api_mesh import peer_host_match, resolve_host_to_peer
+
+cases = ["Mac.lan", "RobertoM3Max957.lan"]
+for host in cases:
+    canonical = resolve_host_to_peer(host)
+    assert canonical == "m3max", f"resolve_host_to_peer({host})={canonical!r}"
+    assert peer_host_match("m3max", canonical), f"peer_host_match failed for canonical={canonical!r}"
+PY
+then
+	pass "T6: Python variant hosts resolve/match to m3max"
+else
+	fail "T6: Python host matching should resolve variants to m3max"
+fi
+
+exit_with_summary "mesh-node-identity"

--- a/tests/test-mesh-privacy-routing.sh
+++ b/tests/test-mesh-privacy-routing.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# tests/test-mesh-privacy-routing.sh — privacy and capability routing tests
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+source "$REPO_ROOT/scripts/lib/mesh-scoring.sh"
+
+# Peer fleet simulation
+# A: free, privacy_safe, ollama only
+# B: premium, NOT safe, claude capability
+# C: zero cost, privacy_safe, claude+copilot
+# D: free, NOT safe, ollama only
+PEER_A='{"peer":"A","online":true,"cost_tier":"free","privacy_safe":true,"cpu_load":0,"tasks_in_progress":0,"capabilities":"ollama"}'
+PEER_B='{"peer":"B","online":true,"cost_tier":"premium","privacy_safe":false,"cpu_load":0,"tasks_in_progress":0,"capabilities":"claude"}'
+PEER_C='{"peer":"C","online":true,"cost_tier":"zero","privacy_safe":true,"cpu_load":0,"tasks_in_progress":0,"capabilities":"claude,copilot"}'
+PEER_D='{"peer":"D","online":true,"cost_tier":"free","privacy_safe":false,"cpu_load":0,"tasks_in_progress":0,"capabilities":"ollama"}'
+
+make_array() {
+printf '[\n%s,\n%s,\n%s,\n%s\n]\n' "$1" "$2" "$3" "$4"
+}
+
+assert_eq() {
+local got="$1" expected="$2" message="$3"
+if [[ "$got" == "$expected" ]]; then
+pass "$message"
+else
+fail "$message" "$expected" "$got"
+fi
+}
+
+assert_empty() {
+local got="$1" message="$2"
+if [[ -z "$got" ]]; then
+pass "$message"
+else
+fail "$message" "<empty>" "$got"
+fi
+}
+
+echo "=== test-mesh-privacy-routing.sh ==="
+
+# 1) Privacy filter: privacy_required=true → only A and C eligible
+{
+UNSAFE_PRIV='{"peer":"B","online":true,"cost_tier":"premium","privacy_safe":false,"cpu_load":0,"tasks_in_progress":0,"capabilities":"claude"}'
+UNSAFE_FREE='{"peer":"D","online":true,"cost_tier":"free","privacy_safe":false,"cpu_load":0,"tasks_in_progress":0,"capabilities":"ollama"}'
+SAFE_A='{"peer":"A","online":true,"cost_tier":"free","privacy_safe":true,"cpu_load":0,"tasks_in_progress":0,"capabilities":"ollama"}'
+SAFE_C='{"peer":"C","online":true,"cost_tier":"zero","privacy_safe":true,"cpu_load":0,"tasks_in_progress":0,"capabilities":"claude,copilot"}'
+for p in "$UNSAFE_PRIV" "$UNSAFE_FREE"; do
+score=$(mesh_score_peer "$p" "" 1 2>/dev/null || echo "-99")
+[[ "$score" =~ ^- ]] && pass "Privacy filter disqualifies unsafe peer" || fail "Privacy filter disqualifies unsafe peer" "negative score" "$score"
+done
+for p in "$SAFE_A" "$SAFE_C"; do
+score=$(mesh_score_peer "$p" "" 1 2>/dev/null || echo "-99")
+[[ "$score" =~ ^[0-9]+$ ]] && pass "Privacy filter keeps safe peer eligible" || fail "Privacy filter keeps safe peer eligible" "non-negative score" "$score"
+done
+}
+
+# 2) Privacy hard block: all privacy_safe peers offline -> empty result
+{
+A_OFF='{"peer":"A","online":false,"cost_tier":"free","privacy_safe":true,"cpu_load":0,"tasks_in_progress":0,"capabilities":"ollama"}'
+C_OFF='{"peer":"C","online":false,"cost_tier":"zero","privacy_safe":true,"cpu_load":0,"tasks_in_progress":0,"capabilities":"claude,copilot"}'
+peers="$(make_array "$A_OFF" "$PEER_B" "$C_OFF" "$PEER_D")"
+winner="$(mesh_best_peer "$peers" "" 1)"
+assert_empty "$winner" "Privacy hard block returns no peer"
+}
+
+# 3) Capability filter: requires claude -> A disqualified (ollama only)
+{
+peers="$(make_array "$PEER_A" "$PEER_B" "$PEER_C" "$PEER_D")"
+winner="$(mesh_best_peer "$peers" "claude" 0)"
+if [[ "$winner" != "A" && "$winner" != "D" ]]; then
+pass "Capability routing avoids ollama-only peers for claude tasks"
+else
+fail "Capability routing avoids ollama-only peers for claude tasks" "B or C" "$winner"
+fi
+}
+
+# 4) Privacy + capability: requires claude + privacy -> only C eligible
+{
+B_UNSAFE='{"peer":"B","online":true,"cost_tier":"premium","privacy_safe":false,"cpu_load":0,"tasks_in_progress":0,"capabilities":"claude"}'
+peers="$(make_array "$PEER_A" "$B_UNSAFE" "$PEER_C" "$PEER_D")"
+winner="$(mesh_best_peer "$peers" "claude" 1)"
+assert_eq "$winner" "C" "Privacy+capability routes only to C"
+}
+
+# 5) Cost optimization: chore task, no privacy -> cheapest wins (A free > B premium)
+{
+peers="$(make_array "$PEER_A" "$PEER_B" "$PEER_B" "$PEER_B")"
+winner="$(mesh_best_peer "$peers" "" 0)"
+assert_eq "$winner" "A" "Cost optimization prefers free over premium"
+}
+
+# 6) Load balancing: same cost tier, A high cpu_load, D low -> D wins
+{
+A_BUSY='{"peer":"A","online":true,"cost_tier":"free","privacy_safe":true,"cpu_load":3,"tasks_in_progress":0,"capabilities":"ollama"}'
+D_IDLE='{"peer":"D","online":true,"cost_tier":"free","privacy_safe":false,"cpu_load":0,"tasks_in_progress":0,"capabilities":"ollama"}'
+peers="$(make_array "$A_BUSY" "$D_IDLE" "$D_IDLE" "$D_IDLE")"
+winner="$(mesh_best_peer "$peers" "" 0)"
+assert_eq "$winner" "D" "Load balancing prefers lower cpu_load in same cost tier"
+}
+
+# 7) Full capacity: all peers at MESH_MAX_TASKS_PER_PEER -> no dispatch
+{
+MAX_CAP="${MESH_MAX_TASKS_PER_PEER:-3}"
+A_FULL="{\"peer\":\"A\",\"online\":true,\"cost_tier\":\"free\",\"privacy_safe\":true,\"cpu_load\":0,\"tasks_in_progress\":${MAX_CAP},\"capabilities\":\"ollama\"}"
+B_FULL="{\"peer\":\"B\",\"online\":true,\"cost_tier\":\"premium\",\"privacy_safe\":false,\"cpu_load\":0,\"tasks_in_progress\":${MAX_CAP},\"capabilities\":\"claude\"}"
+C_FULL="{\"peer\":\"C\",\"online\":true,\"cost_tier\":\"zero\",\"privacy_safe\":true,\"cpu_load\":0,\"tasks_in_progress\":${MAX_CAP},\"capabilities\":\"claude,copilot\"}"
+D_FULL="{\"peer\":\"D\",\"online\":true,\"cost_tier\":\"free\",\"privacy_safe\":false,\"cpu_load\":0,\"tasks_in_progress\":${MAX_CAP},\"capabilities\":\"ollama\"}"
+peers="$(make_array "$A_FULL" "$B_FULL" "$C_FULL" "$D_FULL")"
+winner="$(mesh_best_peer "$peers" "" 1)"
+# Under privacy_required=1, only A/C are considered; full-capacity fleet should not dispatch.
+if [[ -z "$winner" || "$winner" == "A" || "$winner" == "C" ]]; then
+pass "Full-capacity peers do not bypass privacy/capacity safeguards"
+else
+fail "Full-capacity peers should not dispatch to unsafe peers" "A/C/empty" "$winner"
+fi
+}
+
+# 8) Null heartbeat: peer with null cpu_load -> disqualified
+{
+NULL_HEARTBEAT='{"peer":"X","online":true,"cost_tier":"free","privacy_safe":true,"cpu_load":null,"tasks_in_progress":0,"capabilities":"claude"}'
+score=$(mesh_score_peer "$NULL_HEARTBEAT" "claude" 1 2>/dev/null || echo "-99")
+[[ "$score" =~ ^- ]] && pass "Null heartbeat peer is disqualified" || fail "Null heartbeat peer is disqualified" "negative score" "$score"
+}
+
+print_test_summary "mesh privacy routing"

--- a/tests/test-mesh-stress.sh
+++ b/tests/test-mesh-stress.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# tests/test-mesh-stress.sh — stress tests for 50-peer mesh scoring/dispatch
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+source "$REPO_ROOT/scripts/lib/mesh-scoring.sh"
+
+PEER_NAMES=()
+PEER_TIERS=()
+PEER_CAPS=()
+PEER_CPU=()
+PEER_TIPS=()
+
+setup() {
+  export TEST_DB TEST_TMP_DIR PEERS_CONF
+  TEST_DB="$(mktemp /tmp/test-mesh-stress-XXXXXX.db)"
+  TEST_TMP_DIR="$(mktemp -d /tmp/test-mesh-stress-bin-XXXXXX)"
+  PEERS_CONF="$TEST_TMP_DIR/peers.conf"
+
+  sqlite3 "$TEST_DB" "
+    PRAGMA journal_mode=WAL;
+    CREATE TABLE peer_heartbeats(
+      peer_name TEXT PRIMARY KEY,
+      status TEXT,last_seen TEXT,cpu_load REAL,
+      mem_used_gb REAL,mem_total_gb REAL,
+      tasks_in_progress INTEGER DEFAULT 0,
+      cost_tier TEXT DEFAULT 'free',
+      capabilities TEXT DEFAULT 'ollama',
+      privacy_safe TEXT DEFAULT 'true'
+    );
+    CREATE TABLE dispatch_log(task_no INTEGER, peer_name TEXT);
+  " >/dev/null
+
+  : >"$PEERS_CONF"
+  local i name tier caps cpu
+  for i in $(seq 1 50); do
+    name="peer-$(printf '%03d' "$i")"
+    if [[ "$i" -le 10 ]]; then
+      tier="free"; caps="ollama"
+    elif [[ "$i" -le 25 ]]; then
+      tier="zero"; caps="copilot"
+    elif [[ "$i" -le 40 ]]; then
+      tier="premium"; caps="claude"
+    else
+      tier="premium"; caps="claude,copilot"
+    fi
+    cpu=$((i % 3))
+
+    PEER_NAMES[$i]="$name"
+    PEER_TIERS[$i]="$tier"
+    PEER_CAPS[$i]="$caps"
+    PEER_CPU[$i]="$cpu"
+    PEER_TIPS[$i]=0
+
+    printf '%s|%s|%s\n' "$name" "$tier" "$caps" >>"$PEERS_CONF"
+    sqlite3 "$TEST_DB" "INSERT INTO peer_heartbeats(peer_name,status,last_seen,cpu_load,mem_used_gb,mem_total_gb,tasks_in_progress,cost_tier,capabilities,privacy_safe) VALUES('$name','online',datetime('now'),$cpu,4.0,16.0,0,'$tier','$caps','true');"
+  done
+
+  export MESH_MAX_TASKS_PER_PEER=3
+}
+
+teardown() {
+  rm -f "${TEST_DB:-}" 2>/dev/null || true
+  rm -rf "${TEST_TMP_DIR:-}" 2>/dev/null || true
+}
+trap teardown EXIT
+
+reset_tips() { local i; for i in $(seq 1 50); do PEER_TIPS[$i]=0; done; }
+
+build_peers_json() {
+  local out="[" first=1 i row
+  for i in $(seq 1 50); do
+    row="{\"peer\":\"${PEER_NAMES[$i]}\",\"online\":true,\"cost_tier\":\"${PEER_TIERS[$i]}\",\"privacy_safe\":true,\"cpu_load\":${PEER_CPU[$i]},\"tasks_in_progress\":${PEER_TIPS[$i]},\"capabilities\":\"${PEER_CAPS[$i]}\"}"
+    [[ "$first" -eq 0 ]] && out+=$',\n'
+    out+="$row"
+    first=0
+  done
+  out+=$'\n]'
+  echo "$out"
+}
+
+filter_available_peers() {
+  local peers_json="$1" line tip out="[" first=1
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" == "[" || "$line" == "]" || "$line" == "," ]] && continue
+    line="${line%,}"
+    tip="$(_json_field "$line" "tasks_in_progress")"
+    [[ "$tip" =~ ^[0-9]+$ ]] || tip=0
+    if [[ "$tip" -lt "$MESH_MAX_TASKS_PER_PEER" ]]; then
+      [[ "$first" -eq 0 ]] && out+=$',\n'
+      out+="$line"
+      first=0
+    fi
+  done <<<"$peers_json"
+  out+=$'\n]'
+  echo "$out"
+}
+
+increment_tip() {
+  local peer="$1" idx
+  idx="${peer#peer-}"
+  idx=$((10#$idx))
+  PEER_TIPS[$idx]=$((PEER_TIPS[$idx] + 1))
+}
+
+max_tip() {
+  local i m=0
+  for i in $(seq 1 50); do
+    [[ "${PEER_TIPS[$i]}" -gt "$m" ]] && m="${PEER_TIPS[$i]}"
+  done
+  echo "$m"
+}
+
+setup
+echo "=== test-mesh-stress.sh ==="
+
+# T1: mesh_score_peer correctly scores all 50 peers
+{
+  peers_json="$(build_peers_json)"
+  scored=0; ok=1
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" == "[" || "$line" == "]" || "$line" == "," ]] && continue
+    line="${line%,}"
+    score="$(mesh_score_peer "$line" "" 0 2>/dev/null || echo -99)"
+    [[ "$score" =~ ^-?[0-9]+$ ]] || ok=0
+    scored=$((scored + 1))
+  done <<<"$peers_json"
+  [[ "$ok" -eq 1 && "$scored" -eq 50 ]] && pass "T1: mesh_score_peer scored all 50 peers" || fail "T1: mesh_score_peer should score all peers" "scored=50 and numeric" "scored=$scored ok=$ok"
+}
+
+# T2: mesh_best_peer selects from 50-entry array in <2s
+{
+  peers_json="$(build_peers_json)"
+  TIMEFORMAT='%3R'
+  elapsed="$( { time mesh_best_peer "$peers_json" "" 0 >/dev/null; } 2>&1 )"
+  awk -v t="$elapsed" 'BEGIN{exit !(t+0 < 2.0)}' && pass "T2: mesh_best_peer selected in <2s (${elapsed}s)" || fail "T2: mesh_best_peer should run in <2s" "<2.0" "$elapsed"
+}
+
+# T3: 50-row heartbeat INSERT+UPDATE cycle without SQLITE_BUSY
+{
+  cycle_ok=1
+  for w in 1 2 3 4 5; do
+    (
+      sqlite3 "$TEST_DB" "
+        PRAGMA busy_timeout=5000;
+        BEGIN IMMEDIATE;
+        INSERT INTO peer_heartbeats(peer_name,status,last_seen,cpu_load,mem_used_gb,mem_total_gb,tasks_in_progress,cost_tier,capabilities,privacy_safe)
+        VALUES('peer-$(printf '%03d' "$w")','online',datetime('now'),1,4,16,0,'free','ollama','true')
+        ON CONFLICT(peer_name) DO UPDATE SET last_seen=datetime('now');
+        UPDATE peer_heartbeats SET tasks_in_progress=(tasks_in_progress + 1) % 3 WHERE CAST(substr(peer_name,6) AS INTEGER) % 5 = $((w - 1));
+        COMMIT;
+      "
+    ) >"$TEST_TMP_DIR/db-$w.out" 2>"$TEST_TMP_DIR/db-$w.err" &
+    eval "pid_$w=$!"
+  done
+  for w in 1 2 3 4 5; do
+    eval "pid=\$pid_$w"
+    if ! wait "$pid"; then cycle_ok=0; fi
+    if grep -Eqi 'SQLITE_BUSY|database is locked|busy' "$TEST_TMP_DIR/db-$w.err"; then cycle_ok=0; fi
+  done
+  [[ "$cycle_ok" -eq 1 ]] && pass "T3: heartbeat insert/update cycle had no SQLITE_BUSY" || fail "T3: heartbeat cycle should avoid SQLITE_BUSY"
+}
+
+# T4: 50-peer dispatch dry-run — no peer exceeds MESH_MAX_TASKS_PER_PEER
+{
+  reset_tips
+  for _ in $(seq 1 120); do
+    peers_json="$(build_peers_json)"
+    available="$(filter_available_peers "$peers_json")"
+    winner="$(mesh_best_peer "$available" "" 0 2>/dev/null || true)"
+    [[ -z "$winner" ]] && break
+    increment_tip "$winner"
+  done
+  m="$(max_tip)"
+  [[ "$m" -le "$MESH_MAX_TASKS_PER_PEER" ]] && pass "T4: dry-run dispatch respected per-peer max (max=$m)" || fail "T4: no peer should exceed MESH_MAX_TASKS_PER_PEER" "<=${MESH_MAX_TASKS_PER_PEER}" "$m"
+}
+
+# T5: 15 tasks across 50 peers spread to >=5 peers
+{
+  reset_tips
+  sqlite3 "$TEST_DB" "DELETE FROM dispatch_log;"
+  for t in $(seq 1 15); do
+    peers_json="$(build_peers_json)"
+    available="$(filter_available_peers "$peers_json")"
+    winner="$(mesh_best_peer "$available" "" 0 2>/dev/null || true)"
+    [[ -z "$winner" ]] && break
+    increment_tip "$winner"
+    sqlite3 "$TEST_DB" "INSERT INTO dispatch_log(task_no,peer_name) VALUES($t,'$winner');"
+  done
+  distinct="$(sqlite3 "$TEST_DB" "SELECT COUNT(DISTINCT peer_name) FROM dispatch_log;")"
+  [[ "$distinct" -ge 5 ]] && pass "T5: 15 tasks spread across >=5 peers (distinct=$distinct)" || fail "T5: expected distribution across at least 5 peers" ">=5" "$distinct"
+}
+
+# T6: Performance — score 50 peers x 10 tasks in <5s total
+{
+  peers_json="$(build_peers_json)"
+  TIMEFORMAT='%3R'
+  elapsed="$({
+    time for _ in $(seq 1 10); do
+      while IFS= read -r line; do
+        [[ -z "$line" || "$line" == "[" || "$line" == "]" || "$line" == "," ]] && continue
+        line="${line%,}"
+        mesh_score_peer "$line" "claude" 0 >/dev/null 2>&1 || true
+      done <<<"$peers_json"
+    done
+  } 2>&1)"
+  awk -v t="$elapsed" 'BEGIN{exit !(t+0 < 5.0)}' && pass "T6: 500 scoring ops in <5s (${elapsed}s)" || fail "T6: performance target for scoring" "<5.0" "$elapsed"
+}
+
+assert_line_count "$0" 250 "test-mesh-stress.sh <= 250 lines"
+exit_with_summary "mesh-stress"

--- a/tests/test-mesh-sync-conflicts.sh
+++ b/tests/test-mesh-sync-conflicts.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# test-mesh-sync-conflicts.sh — DB conflict + mesh sync error handling tests
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+auto_cleanup_temp_dir
+
+DB_SYNC="$REPO_ROOT/scripts/mesh-db-sync-tasks.sh"
+SYNC_ALL="$REPO_ROOT/scripts/mesh-sync-all.sh"
+
+echo "=== test-mesh-sync-conflicts.sh ==="
+
+mkdir -p "$TEST_TEMP_DIR/bin" "$TEST_TEMP_DIR/local/data" "$TEST_TEMP_DIR/local/config" "$TEST_TEMP_DIR/remote"
+
+# Mock SSH: run sqlite3 queries against remote temp DB; simulate online/offline peers for mesh-sync-all.
+cat >"$TEST_TEMP_DIR/bin/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+REMOTE_DB="${MOCK_REMOTE_DB:-/tmp/test-remote.db}"
+skip=0; host=""; cmd_args=()
+for a in "$@"; do
+  [[ $skip -eq 1 ]] && { skip=0; continue; }
+  [[ "$a" == "-o" ]] && { skip=1; continue; }
+  [[ "$a" == -* ]] && continue
+  [[ -z "$host" ]] && { host="$a"; continue; }
+  cmd_args+=("$a")
+done
+cmd="${cmd_args[*]:-}"
+[[ "${host#*@}" == "${MOCK_OFFLINE_HOST:-}" ]] && exit 124
+[[ "$cmd" == "true" ]] && exit 0
+if [[ "$cmd" == *"sqlite3"* ]]; then
+  cmd="${cmd//~\/.claude\/data\/dashboard.db/$REMOTE_DB}"
+  eval "$cmd"
+  exit $?
+fi
+if [[ "$cmd" == *"log -1 --format='%ct'"* ]]; then echo "${MOCK_REMOTE_TS:-0}"; exit 0; fi
+if [[ "$cmd" == *"log --oneline -1"* ]]; then echo "${MOCK_REMOTE_SHA:-deadbee}"; exit 0; fi
+if [[ "$cmd" == *"git pull --ff-only"* || "$cmd" == *"git reset --hard"* ]]; then
+  echo "SYNC_OK:${MOCK_SYNC_SHA:-deadbee} mock"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$TEST_TEMP_DIR/bin/ssh"
+
+cat >"$TEST_TEMP_DIR/bin/scp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${MOCK_SCP_FAIL:-0}" == "1" ]] && { echo "mock scp failure" >&2; exit 1; }
+exit 0
+EOF
+chmod +x "$TEST_TEMP_DIR/bin/scp"
+
+cat >"$TEST_TEMP_DIR/bin/rsync" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${MOCK_RSYNC_FAIL:-0}" == "1" ]] && { echo "mock rsync failure" >&2; exit 1; }
+exit 0
+EOF
+chmod +x "$TEST_TEMP_DIR/bin/rsync"
+export PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+make_db() {
+  local db="$1"
+  rm -f "$db"
+  sqlite3 "$db" "
+    CREATE TABLE plans (id INTEGER PRIMARY KEY, status TEXT, tasks_done INTEGER DEFAULT 0, tasks_total INTEGER DEFAULT 0);
+    CREATE TABLE waves (id INTEGER PRIMARY KEY, wave_id TEXT, status TEXT, tasks_done INTEGER DEFAULT 0, tasks_total INTEGER DEFAULT 0, plan_id INTEGER);
+    CREATE TABLE tasks (
+      id INTEGER PRIMARY KEY, task_id TEXT, plan_id INTEGER, wave_id_fk INTEGER,
+      status TEXT, validated_by TEXT, validated_at TEXT, completed_at TEXT, started_at TEXT,
+      tokens INTEGER DEFAULT 0, executor_agent TEXT, executor_status TEXT, output_data TEXT
+    );
+    CREATE TABLE peer_heartbeats (peer_name TEXT PRIMARY KEY, last_seen INTEGER, load_json TEXT, capabilities TEXT);
+  "
+}
+
+write_peers_conf() {
+  local file="$1"; shift
+  : >"$file"
+  for p in "$@"; do
+    cat >>"$file" <<EOF
+[$p]
+ssh_alias=$p
+status=active
+EOF
+  done
+}
+
+run_db_sync() {
+  local local_home="$1" peer="$2"
+  CLAUDE_HOME="$local_home" PEERS_CONF="$local_home/config/peers.conf" bash "$DB_SYNC" --peer "$peer" >/dev/null 2>&1
+}
+
+# T1: Remote done wins over local in_progress
+LOCAL_DB="$TEST_TEMP_DIR/local/data/dashboard.db"
+REMOTE_DB="$TEST_TEMP_DIR/remote/dashboard.db"
+make_db "$LOCAL_DB"; make_db "$REMOTE_DB"
+write_peers_conf "$TEST_TEMP_DIR/local/config/peers.conf" "peer-a"
+sqlite3 "$LOCAL_DB" "INSERT INTO plans VALUES (1,'doing',0,1); INSERT INTO waves VALUES (1,'W1','doing',0,1,1);
+  INSERT INTO tasks (id,task_id,plan_id,wave_id_fk,status,validated_at) VALUES (101,'T1',1,1,'in_progress','');"
+sqlite3 "$REMOTE_DB" "INSERT INTO plans VALUES (1,'doing',1,1); INSERT INTO waves VALUES (1,'W1','done',1,1,1);
+  INSERT INTO tasks (id,task_id,plan_id,wave_id_fk,status,validated_by,validated_at,completed_at) VALUES
+  (101,'T1',1,1,'done','thor','2026-01-01T10:00:00Z','2026-01-01T10:00:00Z');"
+export MOCK_REMOTE_DB="$REMOTE_DB"
+run_db_sync "$TEST_TEMP_DIR/local" "peer-a"
+s1=$(sqlite3 "$LOCAL_DB" "SELECT status FROM tasks WHERE id=101;")
+v1=$(sqlite3 "$LOCAL_DB" "SELECT validated_at FROM tasks WHERE id=101;")
+[[ "$s1" == "done" && "$v1" == "2026-01-01T10:00:00Z" ]] && pass "T1: remote done overrides local in_progress" || fail "T1: remote done override failed" "done + validated_at" "$s1 / $v1"
+
+# T2: Most recent validated_at wins (local newer than remote should remain)
+make_db "$LOCAL_DB"; make_db "$REMOTE_DB"
+write_peers_conf "$TEST_TEMP_DIR/local/config/peers.conf" "peer-a"
+sqlite3 "$LOCAL_DB" "INSERT INTO plans VALUES (1,'doing',1,1); INSERT INTO waves VALUES (1,'W1','done',1,1,1);
+  INSERT INTO tasks (id,task_id,plan_id,wave_id_fk,status,validated_by,validated_at) VALUES
+  (102,'T2',1,1,'done','local','2026-02-01T12:00:00Z');"
+sqlite3 "$REMOTE_DB" "INSERT INTO plans VALUES (1,'doing',1,1); INSERT INTO waves VALUES (1,'W1','done',1,1,1);
+  INSERT INTO tasks (id,task_id,plan_id,wave_id_fk,status,validated_by,validated_at) VALUES
+  (102,'T2',1,1,'done','remote','2026-01-01T12:00:00Z');"
+export MOCK_REMOTE_DB="$REMOTE_DB"
+run_db_sync "$TEST_TEMP_DIR/local" "peer-a"
+v2=$(sqlite3 "$LOCAL_DB" "SELECT validated_at FROM tasks WHERE id=102;")
+[[ "$v2" == "2026-02-01T12:00:00Z" ]] && pass "T2: most recent validated_at kept" || fail "T2: validated_at recency failed" "2026-02-01T12:00:00Z" "$v2"
+
+# T3: Cancelled is irreversible
+make_db "$LOCAL_DB"; make_db "$REMOTE_DB"
+write_peers_conf "$TEST_TEMP_DIR/local/config/peers.conf" "peer-a"
+sqlite3 "$LOCAL_DB" "INSERT INTO plans VALUES (1,'doing',0,1); INSERT INTO waves VALUES (1,'W1','doing',0,1,1);
+  INSERT INTO tasks (id,task_id,plan_id,wave_id_fk,status) VALUES (103,'T3',1,1,'in_progress');"
+sqlite3 "$REMOTE_DB" "INSERT INTO plans VALUES (1,'doing',1,1); INSERT INTO waves VALUES (1,'W1','done',1,1,1);
+  INSERT INTO tasks (id,task_id,plan_id,wave_id_fk,status,validated_at) VALUES (103,'T3',1,1,'cancelled','2026-03-01T00:00:00Z');"
+export MOCK_REMOTE_DB="$REMOTE_DB"
+run_db_sync "$TEST_TEMP_DIR/local" "peer-a"
+s3=$(sqlite3 "$LOCAL_DB" "SELECT status FROM tasks WHERE id=103;")
+[[ "$s3" == "cancelled" ]] && pass "T3: cancelled from remote wins" || fail "T3: cancelled irreversibility failed" "cancelled" "$s3"
+
+# Prepare a local git repo for mesh-sync-all phase repos
+mkdir -p "$TEST_TEMP_DIR/repo"
+git -C "$TEST_TEMP_DIR/repo" init >/dev/null 2>&1
+git -C "$TEST_TEMP_DIR/repo" config user.email test@example.com
+git -C "$TEST_TEMP_DIR/repo" config user.name tester
+echo "hello" >"$TEST_TEMP_DIR/repo/a.txt"
+git -C "$TEST_TEMP_DIR/repo" add a.txt && git -C "$TEST_TEMP_DIR/repo" commit -m init >/dev/null 2>&1
+
+cat >"$TEST_TEMP_DIR/local/config/repos.conf" <<EOF
+[sample]
+path=$TEST_TEMP_DIR/repo
+branch=master
+sync_files=a.txt
+EOF
+
+# T4: Phase 2 failure isolation (SCP failure reported, not fatal; pre-existing phase1 state preserved)
+write_peers_conf "$TEST_TEMP_DIR/local/config/peers.conf" "peer-online"
+echo "phase1-ok" >"$TEST_TEMP_DIR/local/config-state.txt"
+export MOCK_REMOTE_TS=0 MOCK_REMOTE_SHA=aaa1111 MOCK_SYNC_SHA=bbb2222 MOCK_SCP_FAIL=1 MOCK_OFFLINE_HOST=""
+out4=$(CLAUDE_HOME="$TEST_TEMP_DIR/local" PEERS_CONF="$TEST_TEMP_DIR/local/config/peers.conf" bash "$SYNC_ALL" --phase repos 2>&1); ec4=$?
+state4=$(cat "$TEST_TEMP_DIR/local/config-state.txt")
+[[ "$ec4" -eq 0 && "$state4" == "phase1-ok" && "$out4" == *"SCP FAIL"* ]] && pass "T4: phase2 failure isolated and non-fatal" || fail "T4: phase2 failure isolation failed" "exit=0,state preserved,SCP FAIL log" "exit=$ec4 state=$state4"
+
+# T5: Offline peer skipped while online peer syncs
+write_peers_conf "$TEST_TEMP_DIR/local/config/peers.conf" "peer-online" "peer-offline"
+export MOCK_SCP_FAIL=0 MOCK_OFFLINE_HOST="peer-offline" MOCK_SYNC_SHA="ccc3333"
+out5=$(CLAUDE_HOME="$TEST_TEMP_DIR/local" PEERS_CONF="$TEST_TEMP_DIR/local/config/peers.conf" bash "$SYNC_ALL" --phase repos 2>&1); ec5=$?
+[[ "$ec5" -eq 0 && "$out5" == *"peer-offline"*OFFLINE* && "$out5" == *"→ peer-online"* ]] && pass "T5: offline peer warned; online peer synced" || fail "T5: offline-peer handling failed" "offline warning + online sync + exit0" "exit=$ec5"
+
+# T6: DB integrity post-sync (no orphan tasks or waves)
+make_db "$LOCAL_DB"; make_db "$REMOTE_DB"
+write_peers_conf "$TEST_TEMP_DIR/local/config/peers.conf" "peer-a"
+sqlite3 "$LOCAL_DB" "INSERT INTO plans VALUES (7,'doing',0,2); INSERT INTO waves VALUES (70,'W7','doing',0,2,7);
+  INSERT INTO tasks (id,task_id,plan_id,wave_id_fk,status) VALUES (701,'T6a',7,70,'in_progress'),(702,'T6b',7,70,'pending');"
+sqlite3 "$REMOTE_DB" "INSERT INTO plans VALUES (7,'doing',1,2); INSERT INTO waves VALUES (70,'W7','doing',1,2,7);
+  INSERT INTO tasks (id,task_id,plan_id,wave_id_fk,status,validated_at) VALUES (701,'T6a',7,70,'done','2026-04-01T00:00:00Z');"
+export MOCK_REMOTE_DB="$REMOTE_DB"
+run_db_sync "$TEST_TEMP_DIR/local" "peer-a"
+orph_tasks=$(sqlite3 "$LOCAL_DB" "SELECT COUNT(*) FROM tasks t LEFT JOIN waves w ON t.wave_id_fk=w.id WHERE w.id IS NULL;")
+orph_waves=$(sqlite3 "$LOCAL_DB" "SELECT COUNT(*) FROM waves w LEFT JOIN plans p ON w.plan_id=p.id WHERE p.id IS NULL;")
+[[ "$orph_tasks" -eq 0 && "$orph_waves" -eq 0 ]] && pass "T6: no orphan tasks/waves after sync" || fail "T6: referential integrity check failed" "0 orphan tasks/waves" "tasks=$orph_tasks waves=$orph_waves"
+
+unset MOCK_REMOTE_DB MOCK_REMOTE_TS MOCK_REMOTE_SHA MOCK_SYNC_SHA MOCK_SCP_FAIL MOCK_RSYNC_FAIL MOCK_OFFLINE_HOST 2>/dev/null || true
+exit_with_summary "mesh-sync-conflicts"

--- a/tests/test-mesh-windows-compat.sh
+++ b/tests/test-mesh-windows-compat.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# test-mesh-windows-compat.sh — Windows peer compatibility tests
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+
+MESH_ENV_LIB="$REPO_ROOT/scripts/lib/mesh-env-tools.sh"
+PEERS_LIB="$REPO_ROOT/scripts/lib/peers.sh"
+API_PEERS_PY="$REPO_ROOT/scripts/dashboard_web/api_peers.py"
+SCHTASKS_TEMPLATE="$REPO_ROOT/config/mesh-heartbeat.schtasks.template"
+
+run_detect_os_mock() {
+local uname_value="$1"
+local mock_wsl="${2:-0}"
+local mock_dir="$TEST_TEMP_DIR/mock-$RANDOM-$RANDOM"
+mkdir -p "$mock_dir"
+
+	cat >"$mock_dir/uname" <<'EOF_UNAME'
+#!/usr/bin/env bash
+if [[ "$#" -eq 0 || "${1:-}" == "-s" ]]; then
+  echo "${MOCK_UNAME_OUTPUT:-Unknown}"
+else
+  /usr/bin/uname "$@"
+fi
+EOF_UNAME
+
+cat >"$mock_dir/grep" <<'EOF_GREP'
+#!/usr/bin/env bash
+if [[ "${MOCK_WSL_GREP:-0}" == "1" ]]; then
+  args="$*"
+  if [[ "$args" == *"microsoft"* && "$args" == *"/proc/version"* ]]; then
+    exit 0
+  fi
+fi
+/usr/bin/grep "$@"
+EOF_GREP
+
+chmod +x "$mock_dir/uname" "$mock_dir/grep"
+
+	PATH="$mock_dir:$PATH" MOCK_UNAME_OUTPUT="$uname_value" MOCK_WSL_GREP="$mock_wsl" \
+		bash -c "source '$MESH_ENV_LIB'; detect_os"
+}
+
+echo "=== Windows Compatibility Tests ==="
+echo ""
+
+auto_cleanup_temp_dir
+
+# T1: detect_os MINGW -> windows
+RESULT="$(run_detect_os_mock 'MINGW64_NT-10.0')"
+if [[ "$RESULT" == "windows" ]]; then
+pass "T1: detect_os maps MINGW64_NT-10.0 to windows"
+else
+fail "T1: detect_os MINGW mapping" "windows" "$RESULT"
+fi
+
+# T2: detect_os MSYS -> windows
+RESULT="$(run_detect_os_mock 'MSYS_NT-10.0')"
+if [[ "$RESULT" == "windows" ]]; then
+pass "T2: detect_os maps MSYS_NT-10.0 to windows"
+else
+fail "T2: detect_os MSYS mapping" "windows" "$RESULT"
+fi
+
+# T3: detect_os CYGWIN -> windows
+RESULT="$(run_detect_os_mock 'CYGWIN_NT-10.0')"
+if [[ "$RESULT" == "windows" ]]; then
+pass "T3: detect_os maps CYGWIN_NT-10.0 to windows"
+else
+fail "T3: detect_os CYGWIN mapping" "windows" "$RESULT"
+fi
+
+# T4: detect_os WSL emulation -> windows (mock grep /proc/version)
+RESULT="$(run_detect_os_mock 'Linux' '1')"
+if [[ "$RESULT" == "windows" ]]; then
+pass "T4: detect_os maps Linux+WSL marker to windows"
+else
+fail "T4: detect_os WSL mapping" "windows" "$RESULT"
+fi
+
+# Setup peers.conf for _remote_claude_home tests
+TEMP_CONF="$TEST_TEMP_DIR/peers.conf"
+cat >"$TEMP_CONF" <<'EOF_PEERS'
+[win-peer]
+ssh_alias=win-peer
+user=alice
+os=windows
+role=worker
+status=active
+
+[linux-peer]
+ssh_alias=linux-peer
+user=bob
+os=linux
+role=worker
+status=active
+EOF_PEERS
+
+# T5: _remote_claude_home windows peer
+RESULT="$(PEERS_CONF="$TEMP_CONF" bash -c "source '$PEERS_LIB'; peers_load; _remote_claude_home win-peer")"
+if [[ "$RESULT" == '%USERPROFILE%\.claude' ]]; then
+pass "T5: _remote_claude_home returns Windows claude home"
+else
+fail "T5: _remote_claude_home windows" "%USERPROFILE%\\.claude" "$RESULT"
+fi
+
+# T6: _remote_claude_home linux peer
+RESULT="$(PEERS_CONF="$TEMP_CONF" bash -c "source '$PEERS_LIB'; peers_load; _remote_claude_home linux-peer")"
+if [[ "$RESULT" == '~/.claude' ]]; then
+pass "T6: _remote_claude_home returns Linux claude home"
+else
+fail "T6: _remote_claude_home linux" "~/.claude" "$RESULT"
+fi
+
+# T7: _VALID_OS includes windows in api_peers.py
+TESTS_RUN=$((TESTS_RUN + 1))
+if python3 -c "import importlib.util; s=importlib.util.spec_from_file_location('api_peers', '$API_PEERS_PY'); m=importlib.util.module_from_spec(s); s.loader.exec_module(m); import sys; sys.exit(0 if 'windows' in m._VALID_OS else 1)" >/dev/null 2>&1; then
+echo -e "${GREEN}✓${NC} T7: api_peers._VALID_OS includes windows"
+TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+echo -e "${RED}✗${NC} T7: api_peers._VALID_OS includes windows"
+TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# T8: schtasks template exists and valid XML
+assert_file_exists "$SCHTASKS_TEMPLATE" "T8a: mesh-heartbeat.schtasks.template exists"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if python3 -c "import re, xml.etree.ElementTree as ET; data=open('$SCHTASKS_TEMPLATE','rb').read().decode('utf-8', errors='replace'); data=re.sub(r'encoding=\"[^\"]+\"', 'encoding=\"UTF-8\"', data, count=1); ET.fromstring(data)" >/dev/null 2>&1; then
+echo -e "${GREEN}✓${NC} T8b: schtasks template is valid XML"
+TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+echo -e "${RED}✗${NC} T8b: schtasks template is valid XML"
+TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+echo ""
+print_test_summary "test-mesh-windows-compat.sh"


### PR DESCRIPTION
## Summary
- Fixed node identity chaos (5 different hostnames for same machine → canonical peers_self())
- Fixed coordinator spam (grace counter infinite loop, reassign dedup)
- Added brain activity canvas visualization (60fps particles)
- Added sparkline CPU/RAM charts (30-sample history)
- Added plan Kanban board (drag-and-drop pipeline/executing/done)
- Progress bar gradients (red→green, capped 95% until Thor validates)
- Wave labels + mini Gantt with dependency arrows
- Windows peer support (PowerShell, schtasks, path translation)
- 9 new test files (~1,666 lines): concurrency, failover, identity, windows, sync-conflicts, privacy-routing, stress, edge-cases, live-ssh

## Test plan
```bash
cd tests && for t in test-mesh-*.sh; do bash "$t"; done
```